### PR TITLE
Update to #26 - Expand GLONASS satellite ID range to include [89-96], si...

### DIFF
--- a/GPSTest/src/main/java/com/android/gpstest/util/GpsTestUtil.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/GpsTestUtil.java
@@ -32,7 +32,7 @@ public class GpsTestUtil {
      */
     public static GnssType getGnssType(int prn) {
         // See Issue #26 for details
-        if (prn >= 65 && prn <= 88) {
+        if (prn >= 65 && prn <= 96) {
             return GnssType.GLONASS;
         } else {
             // Assume US NAVSTAR for now, since we don't have any other info on sat-to-PRN mappings


### PR DESCRIPTION
...nce per NMEA 0183 "[For GLONASS] the numbers 89 through 96 are available if slot numbers above 24 are allocated to on-orbit spares."  See #26 and http://gis.stackexchange.com/questions/65412/is-there-an-industry-standard-official-mapping-of-glonass-satellites-to-prn-va/ for details.
