### PR TITLE
Update to Android Studio 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,7 @@ jdk: oraclejdk7
 
 android:
   components:
-    - build-tools-19.0.1
-
-install:
-  # Prevent `gradle assemble` from being invoked by overriding with no-op
-  - true
+    - build-tools-19.1.0
 
 script:
-  # Use `TERM=dumb` to simplify console output
-  - TERM=dumb ./gradlew assembleDebug -PdisablePreDex
+  - ./gradlew assembleDebug -PdisablePreDex

--- a/GPSTest/build.gradle
+++ b/GPSTest/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8

--- a/ShowcaseViewLibrary/build.gradle
+++ b/ShowcaseViewLibrary/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "android-library"
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 7

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.9.+'
+        classpath 'com.android.tools.build:gradle:0.11.+'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Mar 08 00:23:16 EST 2014
+#Mon Jun 09 13:16:04 EDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip


### PR DESCRIPTION
Requires update to 0.11 Android Gradle plugin, which requires 19.1.0 build tools.  Also bumps Gradle wrapper to 1.12.  Updates Travis script to latest format.
