### PR TITLE
WIP - Fix #103 - Add carrier frequency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ cache:
 
 env:
   global:
-    - ANDROID_API_LEVEL=24
-    - ANDROID_BUILD_TOOLS_VERSION=25.0.2
+    - ANDROID_API_LEVEL=26
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 env:
   global:
     - ANDROID_API_LEVEL=26
+    - ANDROID_BUILD_TOOLS_VERSION=26.0.2
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)

--- a/GPSTest/build.gradle
+++ b/GPSTest/build.gradle
@@ -110,6 +110,7 @@ dependencies {
     compile 'com.google.android.gms:play-services-maps:9.6.1'
     compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'com.google.maps.android:android-maps-utils:0.4.4'
+    compile 'com.android.support:recyclerview-v7:26.1.0'
     // Unit tests that don't rely on Android framework
     testCompile 'junit:junit:4.12'
 }

--- a/GPSTest/build.gradle
+++ b/GPSTest/build.gradle
@@ -111,6 +111,8 @@ dependencies {
     compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'com.google.maps.android:android-maps-utils:0.4.4'
     compile 'com.android.support:recyclerview-v7:26.1.0'
+    // Comparing carrier frequency floating point values
+    compile group: 'com.google.guava', name: 'guava', version: '23.6-android'
     // Unit tests that don't rely on Android framework
     testCompile 'junit:junit:4.12'
 }

--- a/GPSTest/build.gradle
+++ b/GPSTest/build.gradle
@@ -3,11 +3,10 @@ import groovy.swing.SwingBuilder
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 26
 
     defaultConfig {
-        minSdkVersion 9
+        minSdkVersion 14
         targetSdkVersion 21
         versionCode 24
         versionName "2.2.0"
@@ -109,8 +108,7 @@ tasks.whenTaskAdded { theTask ->
 
 dependencies {
     compile 'com.google.android.gms:play-services-maps:9.6.1'
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'org.jraf:android-switch-backport:1.4.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'com.google.maps.android:android-maps-utils:0.4.4'
     // Unit tests that don't rely on Android framework
     testCompile 'junit:junit:4.12'

--- a/GPSTest/src/main/AndroidManifest.xml
+++ b/GPSTest/src/main/AndroidManifest.xml
@@ -44,7 +44,6 @@
             android:theme="@style/Theme.AppCompat">
 
         <activity android:name=".GpsTestActivity"
-                  android:theme="@style/GpsSwitchTheme"
                   android:configChanges="keyboard|keyboardHidden|orientation">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -39,6 +39,7 @@ import android.widget.TextView;
 
 import com.android.gpstest.util.GnssType;
 import com.android.gpstest.util.GpsTestUtil;
+import com.android.gpstest.util.MathUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.Iterator;
@@ -577,7 +578,11 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
                 if (GpsTestUtil.isGnssCarrierFrequenciesSupported()) {
                     if (mCarrierFreqsHz[dataRow] != 0.0f) {
                         // Convert Hz to MHz
-                        v.getCarrierFrequency().setText(Float.toString(mCarrierFreqsHz[dataRow] / 1000000.00f));
+                        v.getCarrierFrequency().setText(Float.toString(MathUtils.toMhz(mCarrierFreqsHz[dataRow])));
+                        // TODO - If carrier signal can't be classified (e.g., not L1 or L5), then shrink text size and show full carrier frequency
+                        //v.getCarrierFrequency().setTextSize(COMPLEX_UNIT_DIP, 10);
+                    } else {
+                        v.getCarrierFrequency().setText("");
                     }
                 }
                 if (mSnrCn0s[dataRow] != 0.0f) {

--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -44,6 +44,8 @@ import com.android.gpstest.util.MathUtils;
 import java.text.SimpleDateFormat;
 import java.util.Iterator;
 
+import static android.util.TypedValue.COMPLEX_UNIT_DIP;
+import static android.util.TypedValue.COMPLEX_UNIT_PX;
 import static com.android.gpstest.util.GpsTestUtil.isFragmentAttached;
 
 
@@ -578,12 +580,27 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
                 if (GpsTestUtil.isGnssCarrierFrequenciesSupported()) {
                     if (mCarrierFreqsHz[dataRow] != 0.0f) {
                         // Convert Hz to MHz
-                        v.getCarrierFrequency().setText(Float.toString(MathUtils.toMhz(mCarrierFreqsHz[dataRow])));
-                        // TODO - If carrier signal can't be classified (e.g., not L1 or L5), then shrink text size and show full carrier frequency
-                        //v.getCarrierFrequency().setTextSize(COMPLEX_UNIT_DIP, 10);
+                        float carrierMhz = MathUtils.toMhz(mCarrierFreqsHz[dataRow]);
+                        String carrierLabel = GpsTestUtil.getCarrierFrequencyLabel(mConstellationType[dataRow],
+                                mPrns[dataRow],
+                                carrierMhz);
+                        if (carrierLabel != null) {
+                            // Make sure it's the normal text size (in case it's previously been
+                            // resized to show raw number).  Use another TextView for default text size.
+                            v.getCarrierFrequency().setTextSize(COMPLEX_UNIT_PX, v.getSvId().getTextSize());
+                            // Show label such as "L1"
+                            v.getCarrierFrequency().setText(carrierLabel);
+                        } else {
+                            // Shrink the size so we can show raw number
+                            v.getCarrierFrequency().setTextSize(COMPLEX_UNIT_DIP, 10);
+                            // Show raw number for carrier frequency
+                            v.getCarrierFrequency().setText(Float.toString(carrierMhz));
+                        }
                     } else {
                         v.getCarrierFrequency().setText("");
                     }
+                } else {
+                    v.getCarrierFrequency().setVisibility(View.GONE);
                 }
                 if (mSnrCn0s[dataRow] != 0.0f) {
                     v.getSignal().setText(Float.toString(mSnrCn0s[dataRow]));

--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -151,9 +151,10 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
         View v = inflater.inflate(R.layout.gps_status, container,
                 false);
 
-        // If this device can't provide signal carrier frequencies (O and higher), then hide the column
         TableLayout tableLayout = v.findViewById(R.id.lat_long_table);
-        tableLayout.setColumnCollapsed(CARRIER_COLUMN, !GpsTestUtil.isGnssCarrierFrequenciesSupported());
+        // FIXME - the below line of code doesn't do anything - we need to modify gridView instead
+        //tableLayout.setColumnCollapsed(CARRIER_COLUMN, !GpsTestUtil.isGnssCarrierFrequenciesSupported());
+
 
         mLatitudeView = (TextView) v.findViewById(R.id.latitude);
         mLongitudeView = (TextView) v.findViewById(R.id.longitude);

--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -18,7 +18,6 @@
 package com.android.gpstest;
 
 import android.annotation.SuppressLint;
-import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.location.GnssMeasurementsEvent;
@@ -30,14 +29,12 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.RequiresApi;
 import android.support.v4.app.Fragment;
-import android.util.Log;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.BaseAdapter;
-import android.widget.GridView;
 import android.widget.ImageView;
-import android.widget.TableLayout;
 import android.widget.TextView;
 
 import com.android.gpstest.util.GnssType;
@@ -53,22 +50,6 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
 
     private final static String TAG = "GpsStatusFragment";
 
-    private static final int PRN_COLUMN = 0;
-
-    private static final int FLAG_IMAGE_COLUMN = 1;
-
-    private static final int CARRIER_COLUMN = 2;
-
-    private static final int SNR_COLUMN = 3;
-
-    private static final int ELEVATION_COLUMN = 4;
-
-    private static final int AZIMUTH_COLUMN = 5;
-
-    private static final int FLAGS_COLUMN = 6;
-
-    private static final int COLUMN_COUNT = 7;
-
     private static final String EMPTY_LAT_LONG = "             ";
 
     SimpleDateFormat mDateFormat = new SimpleDateFormat("hh:mm:ss.SS a");
@@ -79,7 +60,9 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
             mAltitudeMslView, mAccuracyView, mSpeedView, mBearingView, mNumSats,
             mPdopLabelView, mPdopView, mHvdopLabelView, mHvdopView;
 
-    private SvGridAdapter mAdapter;
+    private RecyclerView mStatusList;
+
+    private GnssStatusAdapter mAdapter;
 
     private int mSvCount, mPrns[], mConstellationType[], mUsedInFixCount;
 
@@ -148,13 +131,7 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
             Bundle savedInstanceState) {
 
         mRes = getResources();
-        View v = inflater.inflate(R.layout.gps_status, container,
-                false);
-
-        TableLayout tableLayout = v.findViewById(R.id.lat_long_table);
-        // FIXME - the below line of code doesn't do anything - we need to modify gridView instead
-        //tableLayout.setColumnCollapsed(CARRIER_COLUMN, !GpsTestUtil.isGnssCarrierFrequenciesSupported());
-
+        View v = inflater.inflate(R.layout.gps_status, container,false);
 
         mLatitudeView = (TextView) v.findViewById(R.id.latitude);
         mLongitudeView = (TextView) v.findViewById(R.id.longitude);
@@ -182,11 +159,14 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
         mFlagIndia = getResources().getDrawable(R.drawable.ic_flag_gagan);
         mFlagCanada = getResources().getDrawable(R.drawable.ic_flag_canada);
 
-        GridView gridView = (GridView) v.findViewById(R.id.sv_grid);
-        mAdapter = new SvGridAdapter(getActivity());
-        gridView.setAdapter(mAdapter);
-        gridView.setFocusable(false);
-        gridView.setFocusableInTouchMode(false);
+        mStatusList = v.findViewById(R.id.status_list);
+        mAdapter = new GnssStatusAdapter();
+        mStatusList.setAdapter(mAdapter);
+        mStatusList.setFocusable(false);
+        mStatusList.setFocusableInTouchMode(false);
+        LinearLayoutManager llm = new LinearLayoutManager(getContext());
+        llm.setOrientation(LinearLayoutManager.VERTICAL);
+        mStatusList.setLayoutManager(llm);
 
         GpsTestActivity.getInstance().addListener(this);
 
@@ -450,173 +430,182 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
         mAdapter.notifyDataSetChanged();
     }
 
-    private class SvGridAdapter extends BaseAdapter {
+    private class GnssStatusAdapter extends RecyclerView.Adapter<GnssStatusAdapter.ViewHolder> {
 
-        private Context mContext;
+        class ViewHolder extends RecyclerView.ViewHolder {
+            private final TextView svId;
+            private final TextView gnssFlagHeader;
+            private final ImageView gnssFlag;
+            private final TextView carrierFrequency;
+            private final TextView signal;
+            private final TextView elevation;
+            private final TextView azimuth;
+            private final TextView statusFlags;
 
-        public SvGridAdapter(Context c) {
-            mContext = c;
-        }
-
-        public int getCount() {
-            // add 1 for header row
-            return (mSvCount + 1) * COLUMN_COUNT;
-        }
-
-        public Object getItem(int position) {
-            Log.d(TAG, "getItem(" + position + ")");
-            return "foo";
-        }
-
-        public long getItemId(int position) {
-            return position;
-        }
-
-        public View getView(int position, View convertView, ViewGroup parent) {
-            TextView textView = null;
-            ImageView imageView = null;
-
-            int row = position / COLUMN_COUNT;
-            int column = position % COLUMN_COUNT;
-
-            if (convertView != null) {
-                if (convertView instanceof ImageView) {
-                    imageView = (ImageView) convertView;
-                } else if (convertView instanceof TextView) {
-                    textView = (TextView) convertView;
-                }
+            ViewHolder(View v) {
+                super(v);
+                svId = v.findViewById(R.id.sv_id);
+                gnssFlagHeader = v.findViewById(R.id.gnss_flag_header);
+                gnssFlag = v.findViewById(R.id.gnss_flag);
+                carrierFrequency = v.findViewById(R.id.carrier_frequency);
+                signal = v.findViewById(R.id.signal);
+                elevation = v.findViewById(R.id.elevation);
+                azimuth = v.findViewById(R.id.azimuth);
+                statusFlags = v.findViewById(R.id.status_flags);
             }
 
-            CharSequence text = null;
+            public TextView getSvId() {
+                return svId;
+            }
 
-            if (row == 0) {
-                switch (column) {
-                    case PRN_COLUMN:
-                        text = mRes.getString(R.string.gps_prn_column_label);
-                        break;
-                    case FLAG_IMAGE_COLUMN:
-                        text = mRes.getString(R.string.gps_flag_image_label);
-                        break;
-                    case CARRIER_COLUMN:
-                        if (GpsTestUtil.isGnssCarrierFrequenciesSupported()) {
-                            text = mRes.getString(R.string.gps_carrier_column_label);
-                        }
-                        break;
-                    case SNR_COLUMN:
-                        text = mSnrCn0Title;
-                        break;
-                    case ELEVATION_COLUMN:
-                        text = mRes.getString(R.string.gps_elevation_column_label);
-                        break;
-                    case AZIMUTH_COLUMN:
-                        text = mRes.getString(R.string.gps_azimuth_column_label);
-                        break;
-                    case FLAGS_COLUMN:
-                        text = mRes.getString(R.string.gps_flags_column_label);
-                        break;
+            public TextView getGnssFlagHeader() {
+                return gnssFlagHeader;
+            }
+
+            public ImageView getGnssFlag() {
+                return gnssFlag;
+            }
+
+            public TextView getCarrierFrequency() {
+                return carrierFrequency;
+            }
+
+            public TextView getSignal() {
+                return signal;
+            }
+
+            public TextView getElevation() {
+                return elevation;
+            }
+
+            public TextView getAzimuth() {
+                return azimuth;
+            }
+
+            public TextView getStatusFlags() {
+                return statusFlags;
+            }
+        }
+
+        @Override
+        public ViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
+            View v = LayoutInflater.from(viewGroup.getContext())
+                    .inflate(R.layout.status_row_item, viewGroup, false);
+            return new ViewHolder(v);
+        }
+
+        @Override
+        public int getItemCount() {
+            // Add 1 for header row
+            return mSvCount + 1;
+        }
+
+        public void onBindViewHolder(ViewHolder v, final int position) {
+            if (position == 0) {
+                // Show the header field for the GNSS flag and hide the ImageView
+                v.getGnssFlagHeader().setVisibility(View.VISIBLE);
+                v.getGnssFlag().setVisibility(View.GONE);
+
+                // Populate the header fields
+                v.getSvId().setText(mRes.getString(R.string.gps_prn_column_label));
+                v.getGnssFlagHeader().setText(mRes.getString(R.string.gps_flag_image_label));
+                if (GpsTestUtil.isGnssCarrierFrequenciesSupported()) {
+                    v.getCarrierFrequency().setVisibility(View.VISIBLE);
+                    v.getCarrierFrequency().setText(mRes.getString(R.string.gps_carrier_column_label));
+                } else {
+                    v.getCarrierFrequency().setVisibility(View.GONE);
                 }
+                v.getSignal().setText(mSnrCn0Title);
+                v.getElevation().setText(mRes.getString(R.string.gps_elevation_column_label));
+                v.getAzimuth().setText(mRes.getString(R.string.gps_azimuth_column_label));
+                v.getStatusFlags().setText(mRes.getString(R.string.gps_flags_column_label));
             } else {
-                row--;
-                switch (column) {
-                    case PRN_COLUMN:
-                        text = Integer.toString(mPrns[row]);
+                // There is a header at 0, so the first data row will be at position - 1, etc.
+                int dataRow = position - 1;
+
+                // Show the row field for the GNSS flag image and hide the header
+                v.getGnssFlagHeader().setVisibility(View.GONE);
+                v.getGnssFlag().setVisibility(View.VISIBLE);
+
+                // Populate status data for this row
+                v.getSvId().setText(Integer.toString(mPrns[dataRow]));
+                v.getGnssFlag().setScaleType(ImageView.ScaleType.FIT_START);
+
+                GnssType type;
+                if (GpsTestUtil.isGnssStatusListenerSupported() && !mUseLegacyGnssApi) {
+                    type = GpsTestUtil.getGnssConstellationType(mConstellationType[dataRow], mPrns[dataRow]);
+                } else {
+                    type = GpsTestUtil.getGnssType(mPrns[dataRow]);
+                }
+                switch (type) {
+                    case NAVSTAR:
+                        v.getGnssFlag().setVisibility(View.VISIBLE);
+                        v.getGnssFlag().setImageDrawable(mFlagUsa);
                         break;
-                    case FLAG_IMAGE_COLUMN:
-                        if (imageView == null) {
-                            imageView = new ImageView(mContext);
-                            imageView.setScaleType(ImageView.ScaleType.FIT_START);
-                        }
-                        GnssType type;
-                        if (GpsTestUtil.isGnssStatusListenerSupported() && !mUseLegacyGnssApi) {
-                            type = GpsTestUtil.getGnssConstellationType(mConstellationType[row], mPrns[row]);
-                        } else {
-                            type = GpsTestUtil.getGnssType(mPrns[row]);
-                        }
-                        switch (type) {
-                            case NAVSTAR:
-                                imageView.setVisibility(View.VISIBLE);
-                                imageView.setImageDrawable(mFlagUsa);
-                                break;
-                            case GLONASS:
-                                imageView.setVisibility(View.VISIBLE);
-                                imageView.setImageDrawable(mFlagRussia);
-                                break;
-                            case QZSS:
-                                imageView.setVisibility(View.VISIBLE);
-                                imageView.setImageDrawable(mFlagJapan);
-                                break;
-                            case BEIDOU:
-                                imageView.setVisibility(View.VISIBLE);
-                                imageView.setImageDrawable(mFlagChina);
-                                break;
-                            case GALILEO:
-                                imageView.setVisibility(View.VISIBLE);
-                                imageView.setImageDrawable(mFlagGalileo);
-                                break;
-                            case GAGAN:
-                                imageView.setVisibility(View.VISIBLE);
-                                imageView.setImageDrawable(mFlagIndia);
-                                break;
-                            case ANIK:
-                                imageView.setVisibility(View.VISIBLE);
-                                imageView.setImageDrawable(mFlagCanada);
-                                break;
-                            case GALAXY_15:
-                                imageView.setVisibility(View.VISIBLE);
-                                imageView.setImageDrawable(mFlagUsa);
-                                break;
-                            case UNKNOWN:
-                                imageView.setVisibility(View.INVISIBLE);
-                                break;
-                        }
-                        return imageView;
-                    case CARRIER_COLUMN:
-                        if (GpsTestUtil.isGnssCarrierFrequenciesSupported()) {
-                            if (mCarrierFreqsHz[row] != 0.0f) {
-                                // Convert Hz to MHz
-                                text = Float.toString(mCarrierFreqsHz[row] / 1000000.00f);
-                            }
-                        }
+                    case GLONASS:
+                        v.getGnssFlag().setVisibility(View.VISIBLE);
+                        v.getGnssFlag().setImageDrawable(mFlagRussia);
                         break;
-                    case SNR_COLUMN:
-                        if (mSnrCn0s[row] != 0.0f) {
-                            text = Float.toString(mSnrCn0s[row]);
-                        } else {
-                            text = "";
-                        }
+                    case QZSS:
+                        v.getGnssFlag().setVisibility(View.VISIBLE);
+                        v.getGnssFlag().setImageDrawable(mFlagJapan);
                         break;
-                    case ELEVATION_COLUMN:
-                        if (mSvElevations[row] != 0.0f) {
-                            text = mRes.getString(R.string.gps_elevation_column_value,
-                                    Float.toString(mSvElevations[row]));
-                        } else {
-                            text = "";
-                        }
+                    case BEIDOU:
+                        v.getGnssFlag().setVisibility(View.VISIBLE);
+                        v.getGnssFlag().setImageDrawable(mFlagChina);
                         break;
-                    case AZIMUTH_COLUMN:
-                        if (mSvAzimuths[row] != 0.0f) {
-                            text = mRes.getString(R.string.gps_azimuth_column_value,
-                                    Float.toString(mSvAzimuths[row]));
-                        } else {
-                            text = "";
-                        }
+                    case GALILEO:
+                        v.getGnssFlag().setVisibility(View.VISIBLE);
+                        v.getGnssFlag().setImageDrawable(mFlagGalileo);
                         break;
-                    case FLAGS_COLUMN:
-                        char[] flags = new char[3];
-                        flags[0] = !mHasEphemeris[row] ? ' ' : 'E';
-                        flags[1] = !mHasAlmanac[row] ? ' ' : 'A';
-                        flags[2] = !mUsedInFix[row] ? ' ' : 'U';
-                        text = new String(flags);
+                    case GAGAN:
+                        v.getGnssFlag().setVisibility(View.VISIBLE);
+                        v.getGnssFlag().setImageDrawable(mFlagIndia);
+                        break;
+                    case ANIK:
+                        v.getGnssFlag().setVisibility(View.VISIBLE);
+                        v.getGnssFlag().setImageDrawable(mFlagCanada);
+                        break;
+                    case GALAXY_15:
+                        v.getGnssFlag().setVisibility(View.VISIBLE);
+                        v.getGnssFlag().setImageDrawable(mFlagUsa);
+                        break;
+                    case UNKNOWN:
+                        v.getGnssFlag().setVisibility(View.INVISIBLE);
                         break;
                 }
-            }
+                if (GpsTestUtil.isGnssCarrierFrequenciesSupported()) {
+                    if (mCarrierFreqsHz[dataRow] != 0.0f) {
+                        // Convert Hz to MHz
+                        v.getCarrierFrequency().setText(Float.toString(mCarrierFreqsHz[dataRow] / 1000000.00f));
+                    }
+                }
+                if (mSnrCn0s[dataRow] != 0.0f) {
+                    v.getSignal().setText(Float.toString(mSnrCn0s[dataRow]));
+                } else {
+                    v.getSignal().setText("");
+                }
 
-            if (textView == null) {
-                textView = new TextView(mContext);
-            }
+                if (mSvElevations[dataRow] != 0.0f) {
+                    v.getElevation().setText(mRes.getString(R.string.gps_elevation_column_value,
+                                    Float.toString(mSvElevations[dataRow])));
+                } else {
+                    v.getElevation().setText("");
+                }
 
-            textView.setText(text);
-            return textView;
+                if (mSvAzimuths[dataRow] != 0.0f) {
+                    v.getAzimuth().setText(mRes.getString(R.string.gps_azimuth_column_value,
+                            Float.toString(mSvAzimuths[dataRow])));
+                } else {
+                    v.getAzimuth().setText("");
+                }
+
+                char[] flags = new char[3];
+                flags[0] = !mHasEphemeris[dataRow] ? ' ' : 'E';
+                flags[1] = !mHasAlmanac[dataRow] ? ' ' : 'A';
+                flags[2] = !mUsedInFix[dataRow] ? ' ' : 'U';
+                v.getStatusFlags().setText(new String(flags));
+            }
         }
     }
 }

--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -571,7 +571,10 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
                         return imageView;
                     case CARRIER_COLUMN:
                         if (GpsTestUtil.isGnssCarrierFrequenciesSupported()) {
-                            text = Float.toString(mCarrierFreqsHz[row]);
+                            if (mCarrierFreqsHz[row] != 0.0f) {
+                                // Convert Hz to MHz
+                                text = Float.toString(mCarrierFreqsHz[row] / 1000000.00f);
+                            }
                         }
                         break;
                     case SNR_COLUMN:

--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -58,7 +58,6 @@ import android.view.MenuItem;
 import android.view.Surface;
 import android.view.View;
 import android.view.Window;
-import android.widget.CompoundButton;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -698,22 +697,22 @@ public class GpsTestActivity extends AppCompatActivity
     }
 
     private void initGpsSwitch(Menu menu) {
-        MenuItem item = menu.findItem(R.id.gps_switch);
+        MenuItem item = menu.findItem(R.id.gps_switch_item);
         if (item != null) {
-            mSwitch = (SwitchCompat) MenuItemCompat.getActionView(item);
+            mSwitch = MenuItemCompat.getActionView(item).findViewById(R.id.gps_switch);
             if (mSwitch != null) {
                 // Initialize state of GPS switch before we set the listener, so we don't double-trigger start or stop
                 mSwitch.setChecked(mStarted);
 
-                // Set up listener for GPS on/off switch, since custom menu items on Action Bar don't play
-                // well with ABS and we can't handle in onOptionsItemSelected()
-                mSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                // Set up listener for GPS on/off switch
+                mSwitch.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
                         // Turn GPS on or off
-                        if (!isChecked && mStarted) {
+                        if (!mSwitch.isChecked() && mStarted) {
                             gpsStop();
                         } else {
-                            if (isChecked && !mStarted) {
+                            if (mSwitch.isChecked() && !mStarted) {
                                 gpsStart();
                             }
                         }
@@ -741,7 +740,7 @@ public class GpsTestActivity extends AppCompatActivity
         // Handle menu item selection
         switch (item.getItemId()) {
             case R.id.gps_switch:
-                // Do nothing - this is handled by a separate listener added in onCreateOptionsMenu()
+
                 return true;
             case R.id.delete_aiding_data:
                 // If GPS is currently running, stop it

--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -51,6 +51,7 @@ import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.SwitchCompat;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -110,7 +111,7 @@ public class GpsTestActivity extends AppCompatActivity
 
     boolean mWriteNmeaTimestampToLog;
 
-    org.jraf.android.backport.switchwidget.Switch mSwitch;  //GPS on/off switch
+    private SwitchCompat mSwitch;  // GPS on/off switch
 
     SectionsPagerAdapter mSectionsPagerAdapter;
 
@@ -699,8 +700,7 @@ public class GpsTestActivity extends AppCompatActivity
     private void initGpsSwitch(Menu menu) {
         MenuItem item = menu.findItem(R.id.gps_switch);
         if (item != null) {
-            mSwitch = (org.jraf.android.backport.switchwidget.Switch) MenuItemCompat
-                    .getActionView(item);
+            mSwitch = (SwitchCompat) MenuItemCompat.getActionView(item);
             if (mSwitch != null) {
                 // Initialize state of GPS switch before we set the listener, so we don't double-trigger start or stop
                 mSwitch.setChecked(mStarted);

--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -51,13 +51,13 @@ import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.SwitchCompat;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.Surface;
 import android.view.View;
 import android.view.Window;
+import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -110,7 +110,7 @@ public class GpsTestActivity extends AppCompatActivity
 
     boolean mWriteNmeaTimestampToLog;
 
-    private SwitchCompat mSwitch;  // GPS on/off switch
+    private Switch mSwitch;  // GPS on/off switch
 
     SectionsPagerAdapter mSectionsPagerAdapter;
 

--- a/GPSTest/src/main/java/com/android/gpstest/util/GpsTestUtil.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/GpsTestUtil.java
@@ -149,6 +149,15 @@ public class GpsTestUtil {
     }
 
     /**
+     * Returns true if the platform supports providing carrier frequencies for each satellite, false if it does not
+     *
+     * @return true if the platform supports providing carrier frequencies for each satellite, false if it does not
+     */
+    public static boolean isGnssCarrierFrequenciesSupported() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
+    }
+
+    /**
      * Creates a unique key to identify this satellite using a combination of both the svid and
      * constellation type
      *

--- a/GPSTest/src/main/java/com/android/gpstest/util/GpsTestUtil.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/GpsTestUtil.java
@@ -376,13 +376,13 @@ public class GpsTestUtil {
                 break;
             case GnssStatus.CONSTELLATION_GLONASS:
                 // GnssType.GLONASS
-                if (carrierFrequencyMhz >=1598.0000f && carrierFrequencyMhz >=1610.000f) {
+                if (carrierFrequencyMhz >= 1598.0000f && carrierFrequencyMhz <= 1610.000f) {
                     // Actual range is 1598.0625 MHz to 1609.3125, but allow padding for float comparisons - #103
                     return "L1";
-                } else if (carrierFrequencyMhz >=1242.0000f && carrierFrequencyMhz >=1252.000f) {
+                } else if (carrierFrequencyMhz >= 1242.0000f && carrierFrequencyMhz <= 1252.000f) {
                     // Actual range is 1242.9375 - 1251.6875, but allow padding for float comparisons - #103
                     return "L2";
-                } else if (carrierFrequencyMhz >=1200.0000f && carrierFrequencyMhz >=1210.000f) {
+                } else if (carrierFrequencyMhz >= 1200.0000f && carrierFrequencyMhz <= 1210.000f) {
                     // Exact range is unclear - appears to be 1202.025 - 1207.14 - #103
                     return "L3";
                 } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1176.45f, TOLERANCE_MHZ)) {

--- a/GPSTest/src/main/java/com/android/gpstest/util/GpsTestUtil.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/GpsTestUtil.java
@@ -31,6 +31,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.android.gpstest.DilutionOfPrecision;
+import com.google.common.math.DoubleMath;
 
 import java.util.concurrent.TimeUnit;
 
@@ -342,5 +343,120 @@ public class GpsTestUtil {
             Log.w(TAG, "Input must be a $GNGSA NMEA: " + nmeaSentence);
             return null;
         }
+    }
+
+    /**
+     * Returns the label that should be displayed for a given GNSS constellation, svid, and carrier
+     * frequency in MHz, and obtained from GnssStatus, or null if no carrier frequency label is
+     * found
+     *
+     * @param gnssConstellationType constellation type provided by the GnssStatus.getConstellationType()
+     *                              method
+     * @param svid identification number provided by the GnssStatus.getSvid() method
+     * @param carrierFrequencyMhz carrier frequency for the signal in MHz
+     * @return the label that should be displayed for a given GNSS constellation, svid, and carrier
+     * frequency in MHz, all obtained from GnssStatus, or null if no carrier frequency label is found
+     */
+    public static String getCarrierFrequencyLabel(int gnssConstellationType, int svid, float carrierFrequencyMhz) {
+        final float TOLERANCE_MHZ = 1f;
+        switch (gnssConstellationType) {
+            case GnssStatus.CONSTELLATION_GPS:
+                // GnssType.NAVSTAR
+                if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1575.42f, TOLERANCE_MHZ)) {
+                    return "L1";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1227.6f, TOLERANCE_MHZ)) {
+                    return "L2";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1381.05f, TOLERANCE_MHZ)) {
+                    return "L3";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1379.913f, TOLERANCE_MHZ)) {
+                    return "L4";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1176.45f, TOLERANCE_MHZ)) {
+                    return "L5";
+                }
+                break;
+            case GnssStatus.CONSTELLATION_GLONASS:
+                // GnssType.GLONASS
+                if (carrierFrequencyMhz >=1598.0000f && carrierFrequencyMhz >=1610.000f) {
+                    // Actual range is 1598.0625 MHz to 1609.3125, but allow padding for float comparisons - #103
+                    return "L1";
+                } else if (carrierFrequencyMhz >=1242.0000f && carrierFrequencyMhz >=1252.000f) {
+                    // Actual range is 1242.9375 - 1251.6875, but allow padding for float comparisons - #103
+                    return "L2";
+                } else if (carrierFrequencyMhz >=1200.0000f && carrierFrequencyMhz >=1210.000f) {
+                    // Exact range is unclear - appears to be 1202.025 - 1207.14 - #103
+                    return "L3";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1176.45f, TOLERANCE_MHZ)) {
+                    return "L5";
+                }
+                break;
+            case GnssStatus.CONSTELLATION_BEIDOU:
+                // GnssType.BEIDOU
+                if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1561.098f, TOLERANCE_MHZ)) {
+                    return "B1";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1589.742f, TOLERANCE_MHZ)) {
+                    return "B1-2";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1207.14f, TOLERANCE_MHZ)) {
+                    return "B2";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1176.45f, TOLERANCE_MHZ)) {
+                    return "B2a";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1268.52f, TOLERANCE_MHZ)) {
+                    return "B3";
+                }
+                break;
+            case GnssStatus.CONSTELLATION_QZSS:
+                // GnssType.QZSS;
+                if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1575.42f, TOLERANCE_MHZ)) {
+                    return "L1";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1227.6f, TOLERANCE_MHZ)) {
+                    return "L2";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1176.45f, TOLERANCE_MHZ)) {
+                    return "L5";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1278.75f, TOLERANCE_MHZ)) {
+                    return "LEX";
+                }
+                break;
+            case GnssStatus.CONSTELLATION_GALILEO:
+                // GnssType.GALILEO;
+                if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1575.42f, TOLERANCE_MHZ)) {
+                    return "E1";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1191.795f, TOLERANCE_MHZ)) {
+                    return "E5";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1176.45f, TOLERANCE_MHZ)) {
+                    return "E5a";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1207.14f, TOLERANCE_MHZ)) {
+                    return "E5b";
+                } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1278.75f, TOLERANCE_MHZ)) {
+                    return "E6";
+                }
+                break;
+            case GnssStatus.CONSTELLATION_SBAS:
+                if (svid == 127 || svid == 128 || svid == 139) {
+                    // GnssType.GAGAN
+                    if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1575.42f, TOLERANCE_MHZ)) {
+                        return "L1";
+                    }
+                } else if (svid == 135) {
+                    // GnssType.GALAXY_15;
+                    if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1575.42f, TOLERANCE_MHZ)) {
+                        return "L1";
+                    } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1176.45f, TOLERANCE_MHZ)) {
+                        return "L5";
+                    }
+                } else if (svid == 138) {
+                    // GnssType.ANIK;
+                    if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1575.42f, TOLERANCE_MHZ)) {
+                        return "L1";
+                    } else if (DoubleMath.fuzzyEquals(carrierFrequencyMhz, 1176.45f, TOLERANCE_MHZ)) {
+                        return "L5";
+                    }
+                }
+                break;
+            case GnssStatus.CONSTELLATION_UNKNOWN:
+                break;
+            default:
+                break;
+        }
+        // Unknown carrier frequency for given constellation and svid
+        return null;
     }
 }

--- a/GPSTest/src/main/java/com/android/gpstest/util/MathUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/MathUtils.java
@@ -33,4 +33,13 @@ public class MathUtils {
     public static float mod(float a, float b) {
         return (a % b + b) % b;
     }
+
+    /**
+     * Converts the provided number in Hz to MHz
+     * @param hertz value to be converted
+     * @return value converted to MHz
+     */
+    public static float toMhz(float hertz) {
+        return hertz / 1000000.00f;
+    }
 }

--- a/GPSTest/src/main/res/layout/gps_status.xml
+++ b/GPSTest/src/main/res/layout/gps_status.xml
@@ -161,7 +161,7 @@
               android:padding="4dp"
               android:verticalSpacing="1dp"
               android:horizontalSpacing="2dp"
-              android:numColumns="6"
+        android:numColumns="7"
               android:rowHeight="16dp"
               android:columnWidth="50dp"
               android:stretchMode="columnWidth"

--- a/GPSTest/src/main/res/layout/gps_status.xml
+++ b/GPSTest/src/main/res/layout/gps_status.xml
@@ -158,5 +158,6 @@
     <android.support.v7.widget.RecyclerView
         android:id="@+id/status_list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:layout_marginTop="5dp"/>
 </LinearLayout>

--- a/GPSTest/src/main/res/layout/gps_status.xml
+++ b/GPSTest/src/main/res/layout/gps_status.xml
@@ -161,7 +161,7 @@
               android:padding="4dp"
               android:verticalSpacing="1dp"
               android:horizontalSpacing="2dp"
-        android:numColumns="7"
+              android:numColumns="7"
               android:rowHeight="16dp"
               android:columnWidth="50dp"
               android:stretchMode="columnWidth"

--- a/GPSTest/src/main/res/layout/gps_status.xml
+++ b/GPSTest/src/main/res/layout/gps_status.xml
@@ -155,17 +155,8 @@
         </TableLayout>
     </LinearLayout>
 
-    <GridView android:id="@+id/sv_grid"
-              android:layout_width="fill_parent"
-              android:layout_height="wrap_content"
-              android:padding="4dp"
-              android:verticalSpacing="1dp"
-              android:horizontalSpacing="2dp"
-              android:numColumns="7"
-              android:rowHeight="16dp"
-              android:columnWidth="50dp"
-              android:stretchMode="columnWidth"
-              android:listSelector="@android:color/transparent"
-              android:gravity="center"
-            />
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/status_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
 </LinearLayout>

--- a/GPSTest/src/main/res/layout/gps_switch.xml
+++ b/GPSTest/src/main/res/layout/gps_switch.xml
@@ -24,6 +24,5 @@
     <android.support.v7.widget.SwitchCompat
         android:id="@+id/gps_switch"
         android:layout_width="fill_parent"
-        android:layout_height="match_parent"
-        android:text="@string/gps_switch" />
+        android:layout_height="match_parent" />
 </LinearLayout>

--- a/GPSTest/src/main/res/layout/gps_switch.xml
+++ b/GPSTest/src/main/res/layout/gps_switch.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 /*
 ** Copyright 2013, Sean J. Barbeau
@@ -15,9 +16,14 @@
 ** limitations under the License.
 */
 -->
-<org.jraf.android.backport.switchwidget.Switch
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        tools:context=".GpsTestActivity"/>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.SwitchCompat
+        android:id="@+id/gps_switch"
+        android:layout_width="fill_parent"
+        android:layout_height="match_parent"
+        android:text="@string/gps_switch" />
+</LinearLayout>

--- a/GPSTest/src/main/res/layout/gps_switch.xml
+++ b/GPSTest/src/main/res/layout/gps_switch.xml
@@ -21,7 +21,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.SwitchCompat
+    <android.widget.Switch
         android:id="@+id/gps_switch"
         android:layout_width="fill_parent"
         android:layout_height="match_parent" />

--- a/GPSTest/src/main/res/layout/status_row_item.xml
+++ b/GPSTest/src/main/res/layout/status_row_item.xml
@@ -26,50 +26,58 @@
         android:id="@+id/sv_id"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingRight="@dimen/column_padding"
-        android:paddingEnd="@dimen/column_padding" />
+        android:minWidth="40dp"
+        android:layout_marginRight="@dimen/column_padding"
+        android:layout_marginEnd="@dimen/column_padding" />
     <TextView
         android:id="@+id/gnss_flag_header"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingRight="@dimen/column_padding"
-        android:paddingEnd="@dimen/column_padding"
+        android:minWidth="@dimen/min_column_width"
+        android:layout_marginRight="@dimen/column_padding"
+        android:layout_marginEnd="@dimen/column_padding"
         android:visibility="gone"/>
     <ImageView
         android:id="@+id/gnss_flag"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingRight="@dimen/column_padding"
-        android:paddingEnd="@dimen/column_padding"
+        android:minWidth="@dimen/min_column_width"
+        android:layout_marginRight="@dimen/column_padding"
+        android:layout_marginEnd="@dimen/column_padding"
         android:visibility="gone"/>
     <TextView
         android:id="@+id/carrier_frequency"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingRight="@dimen/column_padding"
-        android:paddingEnd="@dimen/column_padding" />
+        android:minWidth="@dimen/min_column_width"
+        android:layout_marginRight="@dimen/column_padding"
+        android:layout_marginEnd="@dimen/column_padding" />
     <TextView
         android:id="@+id/signal"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingRight="@dimen/column_padding"
-        android:paddingEnd="@dimen/column_padding" />
+        android:minWidth="@dimen/min_column_width"
+        android:layout_marginRight="@dimen/column_padding"
+        android:layout_marginEnd="@dimen/column_padding" />
     <TextView
         android:id="@+id/elevation"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingRight="@dimen/column_padding"
-        android:paddingEnd="@dimen/column_padding" />
+        android:minWidth="@dimen/min_column_width"
+        android:layout_marginRight="@dimen/column_padding"
+        android:layout_marginEnd="@dimen/column_padding" />
     <TextView
         android:id="@+id/azimuth"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingRight="@dimen/column_padding"
-        android:paddingEnd="@dimen/column_padding" />
+        android:minWidth="@dimen/min_column_width"
+        android:layout_marginRight="@dimen/column_padding"
+        android:layout_marginEnd="@dimen/column_padding" />
     <TextView
         android:id="@+id/status_flags"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingRight="@dimen/column_padding"
-        android:paddingEnd="@dimen/column_padding" />
+        android:minWidth="@dimen/min_column_width"
+        android:layout_marginRight="@dimen/column_padding"
+        android:layout_marginEnd="@dimen/column_padding" />
 </LinearLayout>

--- a/GPSTest/src/main/res/layout/status_row_item.xml
+++ b/GPSTest/src/main/res/layout/status_row_item.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+** Copyright 2018, Sean J. Barbeau (sjbarbeau@gmail.com)
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+    android:layout_marginRight="@dimen/activity_horizontal_margin"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <TextView
+        android:id="@+id/sv_id"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingRight="@dimen/column_padding"
+        android:paddingEnd="@dimen/column_padding" />
+    <TextView
+        android:id="@+id/gnss_flag_header"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingRight="@dimen/column_padding"
+        android:paddingEnd="@dimen/column_padding"
+        android:visibility="gone"/>
+    <ImageView
+        android:id="@+id/gnss_flag"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingRight="@dimen/column_padding"
+        android:paddingEnd="@dimen/column_padding"
+        android:visibility="gone"/>
+    <TextView
+        android:id="@+id/carrier_frequency"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingRight="@dimen/column_padding"
+        android:paddingEnd="@dimen/column_padding" />
+    <TextView
+        android:id="@+id/signal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingRight="@dimen/column_padding"
+        android:paddingEnd="@dimen/column_padding" />
+    <TextView
+        android:id="@+id/elevation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingRight="@dimen/column_padding"
+        android:paddingEnd="@dimen/column_padding" />
+    <TextView
+        android:id="@+id/azimuth"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingRight="@dimen/column_padding"
+        android:paddingEnd="@dimen/column_padding" />
+    <TextView
+        android:id="@+id/status_flags"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingRight="@dimen/column_padding"
+        android:paddingEnd="@dimen/column_padding" />
+</LinearLayout>

--- a/GPSTest/src/main/res/menu/gps_menu.xml
+++ b/GPSTest/src/main/res/menu/gps_menu.xml
@@ -28,7 +28,9 @@
         android:showAsAction="ifRoom|withText"
         android:actionLayout="@layout/gps_switch" />  -->
 
-    <item android:id="@+id/gps_switch"
+    <item
+        android:id="@+id/gps_switch_item"
+        android:title="@string/gps_switch"
           app:showAsAction="ifRoom|withText"
           app:actionLayout="@layout/gps_switch"/>
 

--- a/GPSTest/src/main/res/values/dimens.xml
+++ b/GPSTest/src/main/res/values/dimens.xml
@@ -5,4 +5,5 @@
 
     <!-- Status view -->
     <dimen name="column_padding">3dp</dimen>
+    <dimen name="min_column_width">50dp</dimen>
 </resources>

--- a/GPSTest/src/main/res/values/dimens.xml
+++ b/GPSTest/src/main/res/values/dimens.xml
@@ -2,4 +2,7 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+
+    <!-- Status view -->
+    <dimen name="column_padding">3dp</dimen>
 </resources>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -208,7 +208,7 @@
         <b>ID or PRN</b>
         - identifier of this satellite (pseudorandom noise for GPS)\n&#8226;\u0020
         <b>CF</b>
-        - Carrier frequency of the signal being tracked, in MHz (on Android 8.0+, but not supported on all devices)\n&#8226;\u0020
+        - Label (e.g., "L1") for carrier frequency of the signal being tracked. If an unknown frequency, it shows the raw frequency in MHz (available on Android 8.0+, but not supported on all devices)\n&#8226;\u0020
         <b>SNR</b>
         - Signal-to-noise ratio (Android M and lower) (http://bit.ly/SNR-CN0)\n&#8226;\u0020
         <b>C/N0</b>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@
 
     <string name="gps_prn_column_label">ID</string>
     <string name="gps_flag_image_label">GNSS</string>
-    <string name="gps_carrier_column_label">Carrier (MHz)</string>
+    <string name="gps_carrier_column_label">CF</string>
     <string name="gps_snr_column_label">SNR</string>
     <string name="gps_cn0_column_label">C/N0</string>
     <string name="gps_elevation_column_label">Elev</string>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -207,6 +207,8 @@
         - Estimated accuracy (radius in meters of 68% confidence)\n&#8226;\u0020
         <b>ID or PRN</b>
         - identifier of this satellite (pseudorandom noise for GPS)\n&#8226;\u0020
+        <b>CF</b>
+        - Carrier frequency of the signal being tracked, in MHz (on Android 8.0+, but not supported on all devices)\n&#8226;\u0020
         <b>SNR</b>
         - Signal-to-noise ratio (Android M and lower) (http://bit.ly/SNR-CN0)\n&#8226;\u0020
         <b>C/N0</b>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="delete_aiding_data_success">Successfully deleted aiding data.</string>
     <string name="delete_aiding_data_failure">Device does not support deleting aiding data.
     </string>
+    <string name="gps_switch">Switch</string>
     <string name="send_location">Send Location</string>
     <string name="set_fix_frequency">Set Fix Frequency</string>
     <string name="force_time_injection">Inject Time</string>
@@ -71,6 +72,7 @@
 
     <string name="gps_prn_column_label">ID</string>
     <string name="gps_flag_image_label">GNSS</string>
+    <string name="gps_carrier_column_label">Carrier (MHz)</string>
     <string name="gps_snr_column_label">SNR</string>
     <string name="gps_cn0_column_label">C/N0</string>
     <string name="gps_elevation_column_label">Elev</string>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="delete_aiding_data_success">Successfully deleted aiding data.</string>
     <string name="delete_aiding_data_failure">Device does not support deleting aiding data.
     </string>
-    <string name="gps_switch">Switch</string>
+    <string name="gps_switch">Off/On</string>
     <string name="send_location">Send Location</string>
     <string name="set_fix_frequency">Set Fix Frequency</string>
     <string name="force_time_injection">Inject Time</string>

--- a/GPSTest/src/main/res/values/styles.xml
+++ b/GPSTest/src/main/res/values/styles.xml
@@ -15,13 +15,6 @@
 -->
 
 <resources>
-    <style name="Theme.Settings" parent="@style/GpsSwitchTheme">
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowActionBar">false</item>
-
-        <item name="toolbarStyle">@style/Widget.Toolbar</item>
-    </style>
-
     <style name="Widget.Toolbar" parent="@style/Widget.AppCompat.Toolbar">
         <item name="android:background">?attr/colorPrimary</item>
         <item name="android:navigationIcon">?attr/homeAsUpIndicator</item>

--- a/GPSTest/src/main/res/values/themes.xml
+++ b/GPSTest/src/main/res/values/themes.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="GpsSwitchTheme" parent="@style/Theme.AppCompat">
-        <item name="asb_switchStyle">@style/Widget.Holo.CompoundButton.Switch</item>
-    </style>
-</resources>

--- a/GPSTest/src/test/java/com/android/gpstest/GpsTestUtilTest.java
+++ b/GPSTest/src/test/java/com/android/gpstest/GpsTestUtilTest.java
@@ -15,6 +15,8 @@
  */
 package com.android.gpstest;
 
+import android.location.GnssStatus;
+
 import com.android.gpstest.util.GpsTestUtil;
 
 import org.junit.Test;
@@ -97,5 +99,118 @@ public class GpsTestUtilTest {
         assertEquals(2.5d, dop.getPositionDop());
         assertEquals(1.3d, dop.getHorizontalDop());
         assertEquals(2.1d, dop.getVerticalDop());
+    }
+
+    /**
+     * Test converting GNSS signal carrier frequencies to labels like "L1"
+     */
+    @Test
+    public void testGetCarrierFrequencyLabel() {
+        String label;
+
+        // NAVSTAR (GPS)
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GPS, 1, 1575.42f);
+        assertEquals("L1",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GPS, 1, 1227.6f);
+        assertEquals("L2",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GPS, 1, 1381.05f);
+        assertEquals("L3",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GPS, 1, 1379.913f);
+        assertEquals("L4",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GPS, 1, 1176.45f);
+        assertEquals("L5",label);
+
+        // GLONASS
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GLONASS, 1, 	1598.0625f);
+        assertEquals("L1",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GLONASS, 1, 1609.3125f);
+        assertEquals("L1",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GLONASS, 1, 1242.9375f);
+        assertEquals("L2",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GLONASS, 1, 1251.6875f);
+        assertEquals("L2",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GLONASS, 1, 1202.025f);
+        assertEquals("L3",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GLONASS, 1, 1207.14f);
+        assertEquals("L3",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GLONASS, 1, 	1176.45f);
+        assertEquals("L5",label);
+
+        // QZSS
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_QZSS, 1, 	1575.42f);
+        assertEquals("L1",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_QZSS, 1, 	1227.6f);
+        assertEquals("L2",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_QZSS, 1, 	1176.45f);
+        assertEquals("L5",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_QZSS, 1, 	1278.75f);
+        assertEquals("LEX",label);
+
+        // Galileo
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GALILEO, 1, 	1575.42f);
+        assertEquals("E1",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GALILEO, 1, 	1191.795f);
+        assertEquals("E5",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GALILEO, 1, 	1176.45f);
+        assertEquals("E5a",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GALILEO, 1, 	1207.14f);
+        assertEquals("E5b",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GALILEO, 1, 	1278.75f);
+        assertEquals("E6",label);
+
+        // Beidou
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_BEIDOU, 1, 	1561.098f);
+        assertEquals("B1",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_BEIDOU, 1, 	1589.742f);
+        assertEquals("B1-2",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_BEIDOU, 1, 	1207.14f);
+        assertEquals("B2",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_BEIDOU, 1, 	1176.45f);
+        assertEquals("B2a",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_BEIDOU, 1, 	1268.52f);
+        assertEquals("B3",label);
+
+        // GAGAN (SBAS)
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_SBAS, 127, 	1575.42f);
+        assertEquals("L1",label);
+
+        // Galaxy 15 (SBAS)
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_SBAS, 135, 	1575.42f);
+        assertEquals("L1",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_SBAS, 135, 	1176.45f);
+        assertEquals("L5",label);
+
+        // ANIK F1R (SBAS)
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_SBAS, 138, 	1575.42f);
+        assertEquals("L1",label);
+
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_SBAS, 138, 	1176.45f);
+        assertEquals("L5",label);
+
+        // Test variations on the "same" numbers to make sure floating point equality works
+        label = GpsTestUtil.getCarrierFrequencyLabel(GnssStatus.CONSTELLATION_GPS, 1, 1575.420000f);
+        assertEquals("L1",label);
     }
 }

--- a/GPSTest/src/test/java/com/android/gpstest/MathUtilTest.java
+++ b/GPSTest/src/test/java/com/android/gpstest/MathUtilTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2018 Sean J. Barbeau (sjbarbeau@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.gpstest;
+
+import com.android.gpstest.util.MathUtils;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+
+public class MathUtilTest {
+
+    /**
+     * Test converting Hz to MHz
+     */
+    @Test
+    public void testToMhz() {
+        float mhz = MathUtils.toMhz(1000000.0f);
+        assertEquals(1.0f, mhz);
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
     }
 }
 
@@ -12,6 +16,10 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Sep 25 18:20:16 EDT 2016
+#Fri Jan 05 12:59:47 EST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
~~**WIP - Please don't merge**~~

TODO:
- [x] - Hide CF column on < Android 8.0 (and remove FIXME) - Implemented, now test
- [x] - Make the CF column with values fit better.  Right now it's crammed between GNSS flag and C/N0, and with values like `1575.42` there is no padding between the CF and C/N0 columns.  Maybe move it between ID and GNSS flag, and collapse the ID column to wrap the contents?
- [x] - Show labels like `L1` instead of or in addition to the raw CF? (EDIT - Show label when recognized, shrink textview text and show raw frequency when not recognized)
- [x] - Change to use `Switch` instead of `SwitchCompat` (we're at minSdkVersion 14 now, so we really don't need the compatibility library for below 14)