### PR TITLE
Change flag margins to restore previous row height

### DIFF
--- a/GPSTest/src/main/res/layout/status_row_item.xml
+++ b/GPSTest/src/main/res/layout/status_row_item.xml
@@ -42,6 +42,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:minWidth="@dimen/min_column_width"
+        android:layout_marginTop="-2.5dp"
+        android:layout_marginBottom="-2.5dp"
         android:layout_marginRight="@dimen/column_padding"
         android:layout_marginEnd="@dimen/column_padding"
         android:visibility="gone"/>


### PR DESCRIPTION
With the change from GridView to RecyclerView (#104), a change was made from GridView's rowHeight of 16dp and verticalSpacing of 1dp to... well, they simply weren't retained. Due to the sizes of the flag images (they're squares instead of rectangles), the rows grew higher to accommodate them, causing fewer rows to appear on the screen -- on my 4.5" 720x1280 Moto G, the number of rows went from 16 to 13. This proposed change (-2.5dp vertical margin) restores the layout to the previous row height. (I did try setting layout_height to 16dp, but that caused the `ScaleType.FIT_START` to resize the flag smaller.)

Note: I haven't tested this on any other devices, so I don't know if the same row count change will occur elsewhere. (I'm on WinXP, no Intel HAXM support for emulator images, 'twas a bit of an ordeal just getting Android Studio working on it; using 2.3.3.)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Acknowledge that you're contributing your code under Apache v2.0 license

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] If you have multiple commits please combine them into one commit by squashing them.