### PR TITLE
Fix #100 - Flags for WAAS IDs 48 & 51

### DIFF
--- a/GPSTest/src/main/java/com/android/gpstest/util/GpsTestUtil.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/GpsTestUtil.java
@@ -56,9 +56,15 @@ public class GpsTestUtil {
      */
     @Deprecated
     public static GnssType getGnssType(int prn) {
-        if (prn >= 40 && prn <= 41) {
+        if (prn >= 1 && prn <= 32) {
+            return GnssType.NAVSTAR;
+        } else if (prn >= 40 && prn <= 41) {
             // See Issue #92
             return GnssType.GAGAN;
+        } else if (prn == 48) {
+            return GnssType.GALAXY_15;
+        } else if (prn == 51) {
+            return GnssType.ANIK;
         } else if (prn >= 65 && prn <= 96) {
             // See Issue #26 for details
             return GnssType.GLONASS;
@@ -71,8 +77,6 @@ public class GpsTestUtil {
         } else if (prn >= 301 && prn <= 330) {
             // See https://github.com/barbeau/gpstest/issues/58#issuecomment-252235124 for details
             return GnssType.GALILEO;
-        } else if (prn >= 1 && prn <= 32) {
-            return GnssType.NAVSTAR;
         } else {
             return GnssType.UNKNOWN;
         }


### PR DESCRIPTION
This change displays the flags for WAAS IDs 48 and 51 for Android versions below 7.0.

While I was at it, I moved NAVSTAR to the top, both for numerical order and to have it first in the decision tree instead of last (as it tends to be pretty popular for older chipsets).

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Acknowledge that you're contributing your code under Apache v2.0 license

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] If you have multiple commits please combine them into one commit by squashing them.

Here's a screenshot.
![screenshot_00-17-31](https://user-images.githubusercontent.com/173956/35801722-4081b93c-0a22-11e8-9504-fa7d24ac9481.png)
