### PR TITLE
Fix #284 - Allow user to change language within app

### DIFF
--- a/GPSTest/src/main/java/com/android/gpstest/Application.java
+++ b/GPSTest/src/main/java/com/android/gpstest/Application.java
@@ -16,8 +16,12 @@
 
 package com.android.gpstest;
 
+import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.preference.PreferenceManager;
+
+import com.android.gpstest.lang.LocaleManager;
 
 /**
  * Holds application-wide state
@@ -38,6 +42,12 @@ public class Application extends android.app.Application {
         return get().mPrefs;
     }
 
+    private static LocaleManager mLocaleManager;
+
+    public static LocaleManager getLocaleManager() {
+        return mLocaleManager;
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();
@@ -55,5 +65,17 @@ public class Application extends android.app.Application {
     public void onTerminate() {
         super.onTerminate();
         mApp = null;
+    }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        mLocaleManager = new LocaleManager(base);
+        super.attachBaseContext(mLocaleManager.setLocale(base));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        mLocaleManager.setLocale(this);
     }
 }

--- a/GPSTest/src/main/java/com/android/gpstest/BenchmarkController.java
+++ b/GPSTest/src/main/java/com/android/gpstest/BenchmarkController.java
@@ -38,6 +38,11 @@ interface BenchmarkController extends GpsTestListener {
     boolean onBackPressed();
 
     /**
+     * Called from the hosting Activity when it is resumed (e.g., to refresh settings)
+     */
+    void onResume();
+
+    /**
      * Show the Benchmark views
      */
     void show();

--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -116,9 +116,9 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
 
     private String mTtff = "";
 
-    private static final String METERS = Application.get().getString(R.string.preferences_preferred_distance_units_option_meters);
-    private static final String METERS_PER_SECOND = Application.get().getString(R.string.preferences_preferred_speed_units_option_meters_per_second);
-    private static final String KILOMETERS_PER_HOUR = Application.get().getString(R.string.preferences_preferred_speed_units_option_kilometers_per_hour);
+    private static final String METERS = Application.get().getResources().getStringArray(R.array.preferred_distance_units_values)[0];
+    private static final String METERS_PER_SECOND = Application.get().getResources().getStringArray(R.array.preferred_speed_units_values)[0];
+    private static final String KILOMETERS_PER_HOUR = Application.get().getResources().getStringArray(R.array.preferred_speed_units_values)[1];
 
     String mPrefDistanceUnits;
     String mPrefSpeedUnits;
@@ -649,9 +649,9 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
         Application app = Application.get();
 
         mPrefDistanceUnits = settings
-                .getString(app.getString(R.string.pref_key_preferred_distance_units), METERS);
+                .getString(app.getString(R.string.pref_key_preferred_distance_units_v2), METERS);
         mPrefSpeedUnits = settings
-                .getString(app.getString(R.string.pref_key_preferred_speed_units), METERS_PER_SECOND);
+                .getString(app.getString(R.string.pref_key_preferred_speed_units_v2), METERS_PER_SECOND);
     }
 
     /**

--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -319,6 +319,7 @@ public class GpsTestActivity extends AppCompatActivity
                 startActivity(i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
             }
         }
+        mBenchmarkController.onResume();
     }
 
     @Override

--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -220,6 +220,8 @@ public class GpsTestActivity extends AppCompatActivity
 
     private BenchmarkController mBenchmarkController;
 
+    private String mInitialLanguage;
+
     /** Called when the activity is first created. */
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -231,12 +233,15 @@ public class GpsTestActivity extends AppCompatActivity
         requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
         super.onCreate(savedInstanceState);
         mActivity = this;
+        // Reset the activity title to make sure dynamic locale changes are shown
+        UIUtils.resetActivityTitle(this);
 
         saveInstanceState(savedInstanceState);
 
         // Set the default values from the XML file if this is the first
         // execution of the app
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
+        mInitialLanguage = PreferenceUtils.getString(getString(R.string.pref_key_language));
 
         // If we have a large screen, show all the fragments in one layout
         // TODO - Fix large screen layouts (see #122)
@@ -305,6 +310,19 @@ public class GpsTestActivity extends AppCompatActivity
             // loop if user selects "Don't ask again") in system permission prompt
             showLocationPermissionDialog();
         }
+        // If the language has changed since we created the Activity (e.g., returning from Settings), recreate Activity
+        String currentLanguage = PreferenceUtils.getString(getString(R.string.pref_key_language));
+        if (!currentLanguage.equals(mInitialLanguage)) {
+            mInitialLanguage = currentLanguage;
+            Intent i = new Intent(this, GpsTestActivity.class);
+            startActivity(i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
+        }
+    }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        // For dynamically changing the locale
+        super.attachBaseContext(Application.getLocaleManager().setLocale(base));
     }
 
     private void initAccuracy() {

--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -310,12 +310,14 @@ public class GpsTestActivity extends AppCompatActivity
             // loop if user selects "Don't ask again") in system permission prompt
             showLocationPermissionDialog();
         }
-        // If the language has changed since we created the Activity (e.g., returning from Settings), recreate Activity
-        String currentLanguage = PreferenceUtils.getString(getString(R.string.pref_key_language));
-        if (!currentLanguage.equals(mInitialLanguage)) {
-            mInitialLanguage = currentLanguage;
-            Intent i = new Intent(this, GpsTestActivity.class);
-            startActivity(i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
+        // If the set language has changed since we created the Activity (e.g., returning from Settings), recreate Activity
+        if (Application.getPrefs().contains(getString(R.string.pref_key_language))) {
+            String currentLanguage = PreferenceUtils.getString(getString(R.string.pref_key_language));
+            if (!currentLanguage.equals(mInitialLanguage)) {
+                mInitialLanguage = currentLanguage;
+                Intent i = new Intent(this, GpsTestActivity.class);
+                startActivity(i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
+            }
         }
     }
 

--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -315,11 +315,22 @@ public class GpsTestActivity extends AppCompatActivity
             String currentLanguage = PreferenceUtils.getString(getString(R.string.pref_key_language));
             if (!currentLanguage.equals(mInitialLanguage)) {
                 mInitialLanguage = currentLanguage;
-                Intent i = new Intent(this, GpsTestActivity.class);
-                startActivity(i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
+                recreateApp();
             }
         }
         mBenchmarkController.onResume();
+    }
+
+    /**
+     * Destroys and recreates the main activity in a new process.  If we don't use a new process,
+     * the map state and Accuracy ground truth location TextViews get messed up with mixed locales
+     * and partial state retention.
+     */
+    void recreateApp() {
+        Intent i = new Intent(this, GpsTestActivity.class);
+        startActivity(i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
+        // Restart process to destroy and recreate everything
+        System.exit(0);
     }
 
     @Override

--- a/GPSTest/src/main/java/com/android/gpstest/Preferences.java
+++ b/GPSTest/src/main/java/com/android/gpstest/Preferences.java
@@ -156,10 +156,10 @@ public class Preferences extends PreferenceActivity implements
         });
 
         preferredDistanceUnits = (ListPreference) findPreference(
-                getString(R.string.pref_key_preferred_distance_units));
+                getString(R.string.pref_key_preferred_distance_units_v2));
 
         preferredSpeedUnits = (ListPreference) findPreference(
-                getString(R.string.pref_key_preferred_speed_units));
+                getString(R.string.pref_key_preferred_speed_units_v2));
 
         language = (ListPreference) findPreference(getString(R.string.pref_key_language));
         language.setOnPreferenceChangeListener((preference, newValue) -> {
@@ -195,18 +195,18 @@ public class Preferences extends PreferenceActivity implements
     @Override
     protected void onResume() {
         super.onResume();
-        changePreferenceSummary(getString(R.string.pref_key_preferred_distance_units));
-        changePreferenceSummary(getString(R.string.pref_key_preferred_speed_units));
+        changePreferenceSummary(getString(R.string.pref_key_preferred_distance_units_v2));
+        changePreferenceSummary(getString(R.string.pref_key_preferred_speed_units_v2));
         changePreferenceSummary(getString(R.string.pref_key_language));
     }
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (key.equalsIgnoreCase(getString(R.string.pref_key_preferred_distance_units))) {
+        if (key.equalsIgnoreCase(getString(R.string.pref_key_preferred_distance_units_v2))) {
             // Change the preferred distance units description
             changePreferenceSummary(key);
         } else {
-            if (key.equalsIgnoreCase(getString(R.string.pref_key_preferred_speed_units))) {
+            if (key.equalsIgnoreCase(getString(R.string.pref_key_preferred_speed_units_v2))) {
                 // Change the preferred speed units description
                 changePreferenceSummary(key);
             } else {
@@ -264,10 +264,22 @@ public class Preferences extends PreferenceActivity implements
      * @param prefKey preference key that triggers a change in summary
      */
     private void changePreferenceSummary(String prefKey) {
-        if (prefKey.equalsIgnoreCase(getString(R.string.pref_key_preferred_distance_units))) {
-            preferredDistanceUnits.setSummary(preferredDistanceUnits.getValue());
-        } else if (prefKey.equalsIgnoreCase(getString(R.string.pref_key_preferred_speed_units))) {
-            preferredSpeedUnits.setSummary(preferredSpeedUnits.getValue());
+        if (prefKey.equalsIgnoreCase(getString(R.string.pref_key_preferred_distance_units_v2))) {
+            String[] values = Application.get().getResources().getStringArray(R.array.preferred_distance_units_values);
+            String[] entries = Application.get().getResources().getStringArray(R.array.preferred_distance_units_entries);
+            for (int i = 0; i < values.length; i++) {
+                if (values[i].equals(preferredDistanceUnits.getValue())) {
+                    preferredDistanceUnits.setSummary(entries[i]);
+                }
+            }
+        } else if (prefKey.equalsIgnoreCase(getString(R.string.pref_key_preferred_speed_units_v2))) {
+            String[] values = Application.get().getResources().getStringArray(R.array.preferred_speed_units_values);
+            String[] entries = Application.get().getResources().getStringArray(R.array.preferred_speed_units_entries);
+            for (int i = 0; i < values.length; i++) {
+                if (values[i].equals(preferredSpeedUnits.getValue())) {
+                    preferredSpeedUnits.setSummary(entries[i]);
+                }
+            }
         } else if (prefKey.equalsIgnoreCase(getString(R.string.pref_key_language))) {
             String[] values = Application.get().getResources().getStringArray(R.array.language_values);
             String[] entries = Application.get().getResources().getStringArray(R.array.language_entries);

--- a/GPSTest/src/main/java/com/android/gpstest/lang/LocaleManager.java
+++ b/GPSTest/src/main/java/com/android/gpstest/lang/LocaleManager.java
@@ -1,0 +1,74 @@
+/**
+ * Based on https://github.com/YarikSOffice/LanguageTest/blob/master/app/src/main/java/com/yariksoffice/languagetest/LocaleManager.java
+ * Licensed under MIT - https://github.com/YarikSOffice/LanguageTest/blob/master/LICENSE
+ */
+
+package com.android.gpstest.lang;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.preference.PreferenceManager;
+
+import com.android.gpstest.util.LocaleUtils;
+
+import java.util.Locale;
+
+import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
+import static android.os.Build.VERSION_CODES.N;
+
+public class LocaleManager {
+
+    public static final  String LANGUAGE_ENGLISH = "en";
+    public static final  String LANGUAGE_GERMAN = "de";
+    private static final String LANGUAGE_KEY = "language_key";
+
+    private final SharedPreferences prefs;
+
+    public LocaleManager(Context context) {
+        prefs = PreferenceManager.getDefaultSharedPreferences(context);
+    }
+
+    public Context setLocale(Context c) {
+        return updateResources(c, getLanguage());
+    }
+
+    public Context setNewLocale(Context c, String language) {
+        persistLanguage(language);
+        return updateResources(c, language);
+    }
+
+    public String getLanguage() {
+        return prefs.getString(LANGUAGE_KEY, LANGUAGE_ENGLISH);
+    }
+
+    @SuppressLint("ApplySharedPref")
+    private void persistLanguage(String language) {
+        // use commit() instead of apply(), because sometimes we kill the application process immediately
+        // which will prevent apply() to finish
+        prefs.edit().putString(LANGUAGE_KEY, language).commit();
+    }
+
+    private Context updateResources(Context context, String language) {
+        Locale locale = new Locale(language);
+        Locale.setDefault(locale);
+
+        Resources res = context.getResources();
+        Configuration config = new Configuration(res.getConfiguration());
+        if (LocaleUtils.isAtLeastVersion(JELLY_BEAN_MR1)) {
+            config.setLocale(locale);
+            context = context.createConfigurationContext(config);
+        } else {
+            config.locale = locale;
+            res.updateConfiguration(config, res.getDisplayMetrics());
+        }
+        return context;
+    }
+
+    public static Locale getLocale(Resources res) {
+        Configuration config = res.getConfiguration();
+        return LocaleUtils.isAtLeastVersion(N) ? config.getLocales().get(0) : config.locale;
+    }
+}

--- a/GPSTest/src/main/java/com/android/gpstest/lang/LocaleManager.java
+++ b/GPSTest/src/main/java/com/android/gpstest/lang/LocaleManager.java
@@ -12,6 +12,8 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.preference.PreferenceManager;
 
+import com.android.gpstest.Application;
+import com.android.gpstest.R;
 import com.android.gpstest.util.LocaleUtils;
 
 import java.util.Locale;
@@ -19,11 +21,10 @@ import java.util.Locale;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 import static android.os.Build.VERSION_CODES.N;
 
+/**
+ * Dynamically changes the app locale
+ */
 public class LocaleManager {
-
-    public static final  String LANGUAGE_ENGLISH = "en";
-    public static final  String LANGUAGE_GERMAN = "de";
-    private static final String LANGUAGE_KEY = "language_key";
 
     private final SharedPreferences prefs;
 
@@ -32,7 +33,11 @@ public class LocaleManager {
     }
 
     public Context setLocale(Context c) {
-        return updateResources(c, getLanguage());
+        if (!prefs.contains(c.getString(R.string.pref_key_language))) {
+            // User hasn't set the language manually, so use the default context and locale
+            return c;
+        }
+        return updateResources(c, getLanguage(c));
     }
 
     public Context setNewLocale(Context c, String language) {
@@ -40,15 +45,16 @@ public class LocaleManager {
         return updateResources(c, language);
     }
 
-    public String getLanguage() {
-        return prefs.getString(LANGUAGE_KEY, LANGUAGE_ENGLISH);
+    String getLanguage(Context c) {
+        return prefs.getString(c.getString(R.string.pref_key_language),
+                c.getResources().getStringArray(R.array.language_values)[0]); // Default is English
     }
 
     @SuppressLint("ApplySharedPref")
     private void persistLanguage(String language) {
         // use commit() instead of apply(), because sometimes we kill the application process immediately
         // which will prevent apply() to finish
-        prefs.edit().putString(LANGUAGE_KEY, language).commit();
+        prefs.edit().putString(Application.get().getString(R.string.pref_key_language), language).commit();
     }
 
     private Context updateResources(Context context, String language) {

--- a/GPSTest/src/main/java/com/android/gpstest/util/LocaleUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/LocaleUtils.java
@@ -1,0 +1,81 @@
+/**
+ * Based on https://github.com/YarikSOffice/LanguageTest/blob/master/app/src/main/java/com/yariksoffice/languagetest/Utility.java
+ * Licensed under MIT - https://github.com/YarikSOffice/LanguageTest/blob/master/LICENSE
+ */
+package com.android.gpstest.util;
+
+import android.app.Activity;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.res.Resources;
+import android.os.Build;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static android.content.pm.PackageManager.GET_META_DATA;
+import static android.os.Build.VERSION_CODES.P;
+
+public class LocaleUtils {
+
+    public static String hexString(Resources res) {
+        Object resImpl = getPrivateField("android.content.res.Resources", "mResourcesImpl", res);
+        Object o = resImpl != null ? resImpl : res;
+        return "@" + Integer.toHexString(o.hashCode());
+    }
+
+    public static Object getPrivateField(String className, String fieldName, Object object) {
+        try {
+            Class c = Class.forName(className);
+            Field f = c.getDeclaredField(fieldName);
+            f.setAccessible(true);
+            return f.get(object);
+        } catch (Throwable e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public static void resetActivityTitle(Activity a) {
+        try {
+            ActivityInfo info = a.getPackageManager().getActivityInfo(a.getComponentName(), GET_META_DATA);
+            if (info.labelRes != 0) {
+                a.setTitle(info.labelRes);
+            }
+        } catch (NameNotFoundException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static String getTitleCache() {
+        // https://developer.android.com/about/versions/pie/restrictions-non-sdk-interfaces
+        if (isAtLeastVersion(P)) return "Can't access title cache\nstarting from API 28";
+        Object o = getPrivateField("android.app.ApplicationPackageManager", "sStringCache", null);
+        Map<?, WeakReference<CharSequence>> cache = (Map<?, WeakReference<CharSequence>>) o;
+        if (cache == null) return "";
+
+        StringBuilder builder = new StringBuilder("Cache:").append("\n");
+        for (Entry<?, WeakReference<CharSequence>> e : cache.entrySet()) {
+            CharSequence title = e.getValue().get();
+            if (title != null) {
+                builder.append(title).append("\n");
+            }
+        }
+        return builder.toString();
+    }
+
+    public static Resources getTopLevelResources(Activity a) {
+        try {
+            return a.getPackageManager().getResourcesForApplication(a.getApplicationInfo());
+        } catch (NameNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static boolean isAtLeastVersion(int version) {
+        return Build.VERSION.SDK_INT >= version;
+    }
+}

--- a/GPSTest/src/main/java/com/android/gpstest/util/LocaleUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/LocaleUtils.java
@@ -4,76 +4,9 @@
  */
 package com.android.gpstest.util;
 
-import android.app.Activity;
-import android.content.pm.ActivityInfo;
-import android.content.pm.PackageManager.NameNotFoundException;
-import android.content.res.Resources;
 import android.os.Build;
 
-import java.lang.ref.WeakReference;
-import java.lang.reflect.Field;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import static android.content.pm.PackageManager.GET_META_DATA;
-import static android.os.Build.VERSION_CODES.P;
-
 public class LocaleUtils {
-
-    public static String hexString(Resources res) {
-        Object resImpl = getPrivateField("android.content.res.Resources", "mResourcesImpl", res);
-        Object o = resImpl != null ? resImpl : res;
-        return "@" + Integer.toHexString(o.hashCode());
-    }
-
-    public static Object getPrivateField(String className, String fieldName, Object object) {
-        try {
-            Class c = Class.forName(className);
-            Field f = c.getDeclaredField(fieldName);
-            f.setAccessible(true);
-            return f.get(object);
-        } catch (Throwable e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    public static void resetActivityTitle(Activity a) {
-        try {
-            ActivityInfo info = a.getPackageManager().getActivityInfo(a.getComponentName(), GET_META_DATA);
-            if (info.labelRes != 0) {
-                a.setTitle(info.labelRes);
-            }
-        } catch (NameNotFoundException e) {
-            e.printStackTrace();
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    public static String getTitleCache() {
-        // https://developer.android.com/about/versions/pie/restrictions-non-sdk-interfaces
-        if (isAtLeastVersion(P)) return "Can't access title cache\nstarting from API 28";
-        Object o = getPrivateField("android.app.ApplicationPackageManager", "sStringCache", null);
-        Map<?, WeakReference<CharSequence>> cache = (Map<?, WeakReference<CharSequence>>) o;
-        if (cache == null) return "";
-
-        StringBuilder builder = new StringBuilder("Cache:").append("\n");
-        for (Entry<?, WeakReference<CharSequence>> e : cache.entrySet()) {
-            CharSequence title = e.getValue().get();
-            if (title != null) {
-                builder.append(title).append("\n");
-            }
-        }
-        return builder.toString();
-    }
-
-    public static Resources getTopLevelResources(Activity a) {
-        try {
-            return a.getPackageManager().getResourcesForApplication(a.getApplicationInfo());
-        } catch (NameNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     public static boolean isAtLeastVersion(int version) {
         return Build.VERSION.SDK_INT >= version;

--- a/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
@@ -18,8 +18,8 @@ package com.android.gpstest.util;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
@@ -41,6 +41,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.fragment.app.Fragment;
 
+import static android.content.pm.PackageManager.GET_META_DATA;
 import static android.text.TextUtils.isEmpty;
 import static com.android.gpstest.view.GpsSkyView.MAX_VALUE_CN0;
 import static com.android.gpstest.view.GpsSkyView.MAX_VALUE_SNR;
@@ -391,5 +392,21 @@ public class UIUtils {
                 .setPositiveButton(R.string.ok, (dialog, id) -> { })
                 .create()
                 .show();
+    }
+
+    /**
+     * Resets the activity title so the locale is updated
+     *
+     * @param a the activity to reset the title for
+     */
+    public static void resetActivityTitle(Activity a) {
+        try {
+            ActivityInfo info = a.getPackageManager().getActivityInfo(a.getComponentName(), GET_META_DATA);
+            if (info.labelRes != 0) {
+                a.setTitle(info.labelRes);
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/GPSTest/src/main/res/values-cs-rCZ/arrays.xml
+++ b/GPSTest/src/main/res/values-cs-rCZ/arrays.xml
@@ -37,27 +37,6 @@
         <item>Terénní mapa</item>
     </string-array>
 
-    <!-- These contants above and below match those in GoogleMap object:
-        https://developers.google.com/maps/documentation/android/reference/com/google/android/gms/maps/GoogleMap -->
-    <string-array name="map_type_values">
-        <item>1</item>
-        <item>4</item>
-        <item>2</item>
-        <item>3</item>
-    </string-array>
-
-    <!-- Units -->
-    <string-array name="preferred_distance_units_options">
-        <item>@string/preferences_preferred_distance_units_option_meters</item>
-        <item>@string/preferences_preferred_distance_units_option_feet</item>
-    </string-array>
-
-    <string-array name="preferred_speed_units_options">
-        <item>@string/preferences_preferred_speed_units_option_meters_per_second</item>
-        <item>@string/preferences_preferred_speed_units_option_kilometers_per_hour</item>
-        <item>@string/preferences_preferred_speed_units_option_miles_per_hour</item>
-    </string-array>
-
     <!-- Help -->
     <string-array name="main_help_options">
         <item>Co je nového?</item>

--- a/GPSTest/src/main/res/values-de-rDE/arrays.xml
+++ b/GPSTest/src/main/res/values-de-rDE/arrays.xml
@@ -37,27 +37,6 @@
         <item>Geländeansicht</item>
     </string-array>
 
-    <!-- These contants above and below match those in GoogleMap object:
-        https://developers.google.com/maps/documentation/android/reference/com/google/android/gms/maps/GoogleMap -->
-    <string-array name="map_type_values">
-        <item>1</item>
-        <item>4</item>
-        <item>2</item>
-        <item>3</item>
-    </string-array>
-
-    <!-- Units -->
-    <string-array name="preferred_distance_units_options">
-        <item>@string/preferences_preferred_distance_units_option_meters</item>
-        <item>@string/preferences_preferred_distance_units_option_feet</item>
-    </string-array>
-
-    <string-array name="preferred_speed_units_options">
-        <item>@string/preferences_preferred_speed_units_option_meters_per_second</item>
-        <item>@string/preferences_preferred_speed_units_option_kilometers_per_hour</item>
-        <item>@string/preferences_preferred_speed_units_option_miles_per_hour</item>
-    </string-array>
-
     <!-- Help -->
     <string-array name="main_help_options">
         <item>Was ist neu?</item>

--- a/GPSTest/src/main/res/values-el/arrays.xml
+++ b/GPSTest/src/main/res/values-el/arrays.xml
@@ -35,15 +35,6 @@
         <item>Εδαφικός Χάρτης</item>
     </string-array>
 
-    <!-- These contants above and below match those in GoogleMap object:
-        https://developers.google.com/maps/documentation/android/reference/com/google/android/gms/maps/GoogleMap -->
-    <string-array name="map_type_values">
-        <item>1</item>
-        <item>4</item>
-        <item>2</item>
-        <item>3</item>
-    </string-array>
-
     <!-- Help -->
     <string-array name="main_help_options">
         <item>Τι νέο υπάρχει;</item>

--- a/GPSTest/src/main/res/values-it/arrays.xml
+++ b/GPSTest/src/main/res/values-it/arrays.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 /* //device/apps/common/assets/res/any/strings.xml
 **
 ** Copyright 2012, Sean J. Barbeau

--- a/GPSTest/src/main/res/values-it/strings.xml
+++ b/GPSTest/src/main/res/values-it/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 /* //device/apps/common/assets/res/any/strings.xml
 **
 ** Copyright 2008-2018 The Android Open Source Project, Sean J. Barbeau

--- a/GPSTest/src/main/res/values-ja/arrays.xml
+++ b/GPSTest/src/main/res/values-ja/arrays.xml
@@ -37,27 +37,6 @@
         <item>地形図</item>
     </string-array>
 
-    <!-- These contants above and below match those in GoogleMap object:
-        https://developers.google.com/maps/documentation/android/reference/com/google/android/gms/maps/GoogleMap -->
-    <string-array name="map_type_values">
-        <item>1</item>
-        <item>4</item>
-        <item>2</item>
-        <item>3</item>
-    </string-array>
-
-    <!-- Units -->
-    <string-array name="preferred_distance_units_options">
-        <item>@string/preferences_preferred_distance_units_option_meters</item>
-        <item>@string/preferences_preferred_distance_units_option_feet</item>
-    </string-array>
-
-    <string-array name="preferred_speed_units_options">
-        <item>@string/preferences_preferred_speed_units_option_meters_per_second</item>
-        <item>@string/preferences_preferred_speed_units_option_kilometers_per_hour</item>
-        <item>@string/preferences_preferred_speed_units_option_miles_per_hour</item>
-    </string-array>
-
     <!-- Help -->
     <string-array name="main_help_options">
         <item>新しいもの</item>

--- a/GPSTest/src/main/res/values-nl/arrays.xml
+++ b/GPSTest/src/main/res/values-nl/arrays.xml
@@ -47,12 +47,12 @@
     </string-array>
 
     <!-- Units -->
-    <string-array name="preferred_distance_units_options">
+    <string-array name="preferred_distance_units_entries">
         <item>@string/preferences_preferred_distance_units_option_meters</item>
         <item>@string/preferences_preferred_distance_units_option_feet</item>
     </string-array>
 
-    <string-array name="preferred_speed_units_options">
+    <string-array name="preferred_speed_units_entries">
         <item>@string/preferences_preferred_speed_units_option_meters_per_second</item>
         <item>@string/preferences_preferred_speed_units_option_kilometers_per_hour</item>
         <item>@string/preferences_preferred_speed_units_option_miles_per_hour</item>

--- a/GPSTest/src/main/res/values-zh-rCN/arrays.xml
+++ b/GPSTest/src/main/res/values-zh-rCN/arrays.xml
@@ -37,27 +37,6 @@
         <item>地形视图</item>
     </string-array>
 
-    <!-- These contants above and below match those in GoogleMap object:
-        https://developers.google.com/maps/documentation/android/reference/com/google/android/gms/maps/GoogleMap -->
-    <string-array name="map_type_values">
-        <item>1</item>
-        <item>4</item>
-        <item>2</item>
-        <item>3</item>
-    </string-array>
-
-    <!-- Units -->
-    <string-array name="preferred_distance_units_options">
-        <item>@string/preferences_preferred_distance_units_option_meters</item>
-        <item>@string/preferences_preferred_distance_units_option_feet</item>
-    </string-array>
-
-    <string-array name="preferred_speed_units_options">
-        <item>@string/preferences_preferred_speed_units_option_meters_per_second</item>
-        <item>@string/preferences_preferred_speed_units_option_kilometers_per_hour</item>
-        <item>@string/preferences_preferred_speed_units_option_miles_per_hour</item>
-    </string-array>
-
     <!-- Help -->
     <string-array name="main_help_options">
         <item>更新内容</item>

--- a/GPSTest/src/main/res/values/arrays.xml
+++ b/GPSTest/src/main/res/values/arrays.xml
@@ -46,6 +46,19 @@
         <item>3</item>
     </string-array>
 
+    <!-- Supported languages -->
+    <string-array name="language_entries">
+        <item>English</item>
+        <item>Chinese</item>
+        <item>Czech</item>
+        <item>Dutch</item>
+        <item>German</item>
+        <item>Greek</item>
+        <item>Italian</item>
+        <item>Japanese</item>
+        <item>Russian</item>
+    </string-array>
+
     <!-- Units -->
     <string-array name="preferred_distance_units_options">
         <item>@string/preferences_preferred_distance_units_option_meters</item>

--- a/GPSTest/src/main/res/values/arrays.xml
+++ b/GPSTest/src/main/res/values/arrays.xml
@@ -37,7 +37,7 @@
         <item>Terrain View</item>
     </string-array>
 
-    <!-- Supported languages -->
+    <!-- Supported languages, must stay in-order with language_values -->
     <string-array name="language_entries">
         <item>English</item>
         <item>Chinese</item>

--- a/GPSTest/src/main/res/values/do_not_translate.xml
+++ b/GPSTest/src/main/res/values/do_not_translate.xml
@@ -97,8 +97,8 @@
     <string name="pref_key_dark_theme">dark_theme</string>
     <string name="pref_key_never_show_clear_assist_warning">never_show_clear_assist_warning</string>
     <string name="pref_key_dms_mode">dms_mode</string>
-    <string name="pref_key_preferred_distance_units">preference_distance_units</string>
-    <string name="pref_key_preferred_speed_units">preference_speed_units</string>
+    <string name="pref_key_preferred_distance_units_v2">preference_distance_units_v2</string>
+    <string name="pref_key_preferred_speed_units_v2">preference_speed_units_v2</string>
     <string name="pref_key_language">preference_language</string>
 
     <!-- Default preference values -->
@@ -153,18 +153,29 @@
     <string name="capability_value_location_disabled">LOCATION_DISABLED</string>
 
     <!-- Unit preferences-->
-    <string-array name="preferred_distance_units_options">
+    <string-array name="preferred_distance_units_entries">
         <item>@string/preferences_preferred_distance_units_option_meters</item>
         <item>@string/preferences_preferred_distance_units_option_feet</item>
     </string-array>
 
-    <string-array name="preferred_speed_units_options">
+    <string-array name="preferred_distance_units_values">
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
+    <string-array name="preferred_speed_units_entries">
         <item>@string/preferences_preferred_speed_units_option_meters_per_second</item>
         <item>@string/preferences_preferred_speed_units_option_kilometers_per_hour</item>
         <item>@string/preferences_preferred_speed_units_option_miles_per_hour</item>
     </string-array>
 
-    <!-- Supported languages -->
+    <string-array name="preferred_speed_units_values">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+
+    <!-- Supported languages, must stay in-order with language_entries -->
     <string-array name="language_values">
         <item>en</item>
         <item>zh</item>

--- a/GPSTest/src/main/res/values/do_not_translate.xml
+++ b/GPSTest/src/main/res/values/do_not_translate.xml
@@ -53,6 +53,7 @@
     <string name="pref_key_dms_mode">dms_mode</string>
     <string name="pref_key_preferred_distance_units">preference_distance_units</string>
     <string name="pref_key_preferred_speed_units">preference_speed_units</string>
+    <string name="pref_key_language">preference_language</string>
 
     <!-- Default preference values -->
     <string name="pref_gps_min_time_default_sec">1</string>
@@ -95,4 +96,16 @@
     <string name="capability_value_not_supported">NOT_SUPPORTED</string>
     <string name="capability_value_supported">SUPPORTED</string>
     <string name="capability_value_location_disabled">LOCATION_DISABLED</string>
+
+    <string-array name="language_values">
+        <item>en</item>
+        <item>zh</item>
+        <item>cs</item>
+        <item>nl</item>
+        <item>de</item>
+        <item>el</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ru</item>
+    </string-array>
 </resources>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -315,6 +315,10 @@
     <string name="preferences_preferred_speed_units_option_kilometers_per_hour">Kilometers per hour</string>
     <string name="preferences_preferred_speed_units_option_miles_per_hour">Miles per hour</string>
 
+    <string name="pref_language_title">Language</string>
+    <string name="pref_language_summary">Sets the language shown in the app</string>
+    <string name="pref_language_dialog_title">Choose language</string>
+
     <!-- Units -->
     <string name="feet_abbreviation">ft</string>
     <string name="meters_abbreviation">m</string>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -274,7 +274,7 @@
     <string name="preferences_preferred_speed_units_option_miles_per_hour">Miles per hour</string>
 
     <string name="pref_language_title">Language</string>
-    <string name="pref_language_summary">Sets the language shown in the app</string>
+    <string name="pref_language_summary">Manually sets the language shown in the app</string>
     <string name="pref_language_dialog_title">Choose language</string>
 
     <!-- Units -->

--- a/GPSTest/src/main/res/xml/preferences.xml
+++ b/GPSTest/src/main/res/xml/preferences.xml
@@ -9,6 +9,13 @@
             android:title="@string/pref_dark_theme_title"
             android:summary="@string/pref_dark_theme_summary"
             android:defaultValue="false"/>
+        <ListPreference
+            android:key="@string/pref_key_language"
+            android:title="@string/pref_language_title"
+            android:summary="@string/pref_language_summary"
+            android:dialogTitle="@string/pref_language_dialog_title"
+            android:entries="@array/language_entries"
+            android:entryValues="@array/language_values" />
         <CheckBoxPreference
             android:key="@string/pref_key_keep_screen_on"
             android:title="@string/pref_keep_screen_on_title"

--- a/GPSTest/src/main/res/xml/preferences.xml
+++ b/GPSTest/src/main/res/xml/preferences.xml
@@ -32,18 +32,18 @@
             android:summary="@string/pref_dms_mode_summary"
             android:defaultValue="false"/>
         <ListPreference
-            android:key="@string/pref_key_preferred_distance_units"
+            android:key="@string/pref_key_preferred_distance_units_v2"
             android:title="@string/preferences_preferred_distance_units_title"
-            android:entries="@array/preferred_distance_units_options"
-            android:entryValues="@array/preferred_distance_units_options"
-            android:defaultValue="@string/preferences_preferred_distance_units_option_meters">
+            android:entries="@array/preferred_distance_units_entries"
+            android:entryValues="@array/preferred_distance_units_values"
+            android:defaultValue="1">
         </ListPreference>
         <ListPreference
-            android:key="@string/pref_key_preferred_speed_units"
+            android:key="@string/pref_key_preferred_speed_units_v2"
             android:title="@string/preferences_preferred_speed_units_title"
-            android:entries="@array/preferred_speed_units_options"
-            android:entryValues="@array/preferred_speed_units_options"
-            android:defaultValue="@string/preferences_preferred_speed_units_option_meters_per_second">
+            android:entries="@array/preferred_speed_units_entries"
+            android:entryValues="@array/preferred_speed_units_values"
+            android:defaultValue="1">
         </ListPreference>
     </PreferenceCategory>
 

--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -7,6 +7,8 @@ Users have contributed translations in the following languages:
 * Greek
 * Japanese
 * Czech
+* Italian
+* Russian
 
 We would love help improving the existing translations, or adding a new translation.
 


### PR DESCRIPTION
TODO:
- [x] Test initial install
- [x] Test switching languages
- [x] Fix setting Accuracy ground truth after changing languages - currently the dialog still shows old language and validates incorrectly if `.<->,` switch
- [x] Test preferred distance and speed units (Status and Accuracy) and if they are holding correctly