### PR TITLE
Fix #242 - Support Degrees Decimal Minutes coordinate format

### DIFF
--- a/GPSTest/src/androidTest/java/com/android/gpstest/UIUtilsAndroidTest.java
+++ b/GPSTest/src/androidTest/java/com/android/gpstest/UIUtilsAndroidTest.java
@@ -38,13 +38,13 @@ public class UIUtilsAndroidTest {
         // Test German
         setLocale("de", "DE");
 
-        String dms = UIUtils.getDMSFromLocation(getTargetContext(), -42.853583, "lat");
+        String dms = UIUtils.getDMSFromLocation(getTargetContext(), -42.853583, UIUtils.COORDINATE_LATITUDE);
         assertEquals("S\t\u200742° 51' 12,90\"", dms);
 
         // Test English
         setLocale("en", "US");
 
-        dms = UIUtils.getDMSFromLocation(getTargetContext(), -42.853583, "lat");
+        dms = UIUtils.getDMSFromLocation(getTargetContext(), -42.853583, UIUtils.COORDINATE_LATITUDE);
         assertEquals("S\t\u200742° 51' 12.90\"", dms);
     }
 
@@ -53,13 +53,13 @@ public class UIUtilsAndroidTest {
         // Test German
         setLocale("de", "DE");
 
-        String dms = UIUtils.getDMSFromLocation(getTargetContext(), 47.64896, "lon");
+        String dms = UIUtils.getDMSFromLocation(getTargetContext(), 47.64896, UIUtils.COORDINATE_LONGITUDE);
         assertEquals("E\t047° 38' 56,26\"", dms);
 
         // Test English
         setLocale("en", "US");
 
-        dms = UIUtils.getDMSFromLocation(getTargetContext(), 47.64896, "lon");
+        dms = UIUtils.getDMSFromLocation(getTargetContext(), 47.64896, UIUtils.COORDINATE_LONGITUDE);
         assertEquals("E\t047° 38' 56.26\"", dms);
     }
 
@@ -68,13 +68,13 @@ public class UIUtilsAndroidTest {
         // Test German
         setLocale("de", "DE");
 
-        String ddm = UIUtils.getDDMFromLocation(getTargetContext(), 24.15346, "lat");
+        String ddm = UIUtils.getDDMFromLocation(getTargetContext(), 24.15346, UIUtils.COORDINATE_LATITUDE);
         assertEquals("N\t\u200724° 09,208", ddm);
 
         // Test English
         setLocale("en", "US");
 
-        ddm = UIUtils.getDDMFromLocation(getTargetContext(), 24.15346, "lat");
+        ddm = UIUtils.getDDMFromLocation(getTargetContext(), 24.15346, UIUtils.COORDINATE_LATITUDE);
         assertEquals("N\t\u200724° 09.208", ddm);
     }
 
@@ -83,13 +83,13 @@ public class UIUtilsAndroidTest {
         // Test English
         setLocale("en", "US");
 
-        String ddm = UIUtils.getDDMFromLocation(getTargetContext(), -150.94523, "lon");
+        String ddm = UIUtils.getDDMFromLocation(getTargetContext(), -150.94523, UIUtils.COORDINATE_LONGITUDE);
         assertEquals("W\t150° 56.714", ddm);
 
         // Test German
         setLocale("de", "DE");
 
-        ddm = UIUtils.getDDMFromLocation(getTargetContext(), -150.94523, "lon");
+        ddm = UIUtils.getDDMFromLocation(getTargetContext(), -150.94523, UIUtils.COORDINATE_LONGITUDE);
         assertEquals("W\t150° 56,714", ddm);
     }
 

--- a/GPSTest/src/androidTest/java/com/android/gpstest/UIUtilsAndroidTest.java
+++ b/GPSTest/src/androidTest/java/com/android/gpstest/UIUtilsAndroidTest.java
@@ -15,12 +15,12 @@
  */
 package com.android.gpstest;
 
+import androidx.test.runner.AndroidJUnit4;
+
 import com.android.gpstest.util.UIUtils;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.InstrumentationRegistry.getTargetContext;
 import static junit.framework.Assert.assertEquals;
@@ -29,8 +29,26 @@ import static junit.framework.Assert.assertEquals;
 public class UIUtilsAndroidTest {
 
     @Test
-    public void testGetDMSFromLocation() {
-        String dms = UIUtils.getDMSFromLocation(getTargetContext(), -42.853583);
-        assertEquals("-42° 51' 12\"", dms);
+    public void testGetDMSFromLocationLat() {
+        String dms = UIUtils.getDMSFromLocation(getTargetContext(), -42.853583, "lat");
+        assertEquals("S\t\u200742° 51' 12.90\"", dms);
+    }
+
+    @Test
+    public void testGetDMSFromLocationLon() {
+        String dms = UIUtils.getDMSFromLocation(getTargetContext(), 47.64896, "lon");
+        assertEquals("E\t047° 38' 56.26\"", dms);
+    }
+
+    @Test
+    public void testGetDDMFromLocationLat() {
+        String ddm = UIUtils.getDDMFromLocation(getTargetContext(), 24.15346, "lat");
+        assertEquals("N\t\u200724° 09.208", ddm);
+    }
+
+    @Test
+    public void testGetDDMFromLocationLon() {
+        String ddm = UIUtils.getDDMFromLocation(getTargetContext(), -150.94523, "lon");
+        assertEquals("W\t150° 56.714", ddm);
     }
 }

--- a/GPSTest/src/androidTest/java/com/android/gpstest/UIUtilsAndroidTest.java
+++ b/GPSTest/src/androidTest/java/com/android/gpstest/UIUtilsAndroidTest.java
@@ -15,12 +15,17 @@
  */
 package com.android.gpstest;
 
+import android.content.res.Configuration;
+import android.content.res.Resources;
+
 import androidx.test.runner.AndroidJUnit4;
 
 import com.android.gpstest.util.UIUtils;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Locale;
 
 import static androidx.test.InstrumentationRegistry.getTargetContext;
 import static junit.framework.Assert.assertEquals;
@@ -30,25 +35,72 @@ public class UIUtilsAndroidTest {
 
     @Test
     public void testGetDMSFromLocationLat() {
+        // Test German
+        setLocale("de", "DE");
+
         String dms = UIUtils.getDMSFromLocation(getTargetContext(), -42.853583, "lat");
+        assertEquals("S\t\u200742° 51' 12,90\"", dms);
+
+        // Test English
+        setLocale("en", "US");
+
+        dms = UIUtils.getDMSFromLocation(getTargetContext(), -42.853583, "lat");
         assertEquals("S\t\u200742° 51' 12.90\"", dms);
     }
 
     @Test
     public void testGetDMSFromLocationLon() {
+        // Test German
+        setLocale("de", "DE");
+
         String dms = UIUtils.getDMSFromLocation(getTargetContext(), 47.64896, "lon");
+        assertEquals("E\t047° 38' 56,26\"", dms);
+
+        // Test English
+        setLocale("en", "US");
+
+        dms = UIUtils.getDMSFromLocation(getTargetContext(), 47.64896, "lon");
         assertEquals("E\t047° 38' 56.26\"", dms);
     }
 
     @Test
     public void testGetDDMFromLocationLat() {
+        // Test German
+        setLocale("de", "DE");
+
         String ddm = UIUtils.getDDMFromLocation(getTargetContext(), 24.15346, "lat");
+        assertEquals("N\t\u200724° 09,208", ddm);
+
+        // Test English
+        setLocale("en", "US");
+
+        ddm = UIUtils.getDDMFromLocation(getTargetContext(), 24.15346, "lat");
         assertEquals("N\t\u200724° 09.208", ddm);
     }
 
     @Test
     public void testGetDDMFromLocationLon() {
+        // Test English
+        setLocale("en", "US");
+
         String ddm = UIUtils.getDDMFromLocation(getTargetContext(), -150.94523, "lon");
         assertEquals("W\t150° 56.714", ddm);
+
+        // Test German
+        setLocale("de", "DE");
+
+        ddm = UIUtils.getDDMFromLocation(getTargetContext(), -150.94523, "lon");
+        assertEquals("W\t150° 56,714", ddm);
+    }
+
+    private void setLocale(String language, String country) {
+        Locale locale = new Locale(language, country);
+        // Update locale for date formatters
+        Locale.setDefault(locale);
+        // Update locale for app resources
+        Resources res = getTargetContext().getResources();
+        Configuration config = res.getConfiguration();
+        config.locale = locale;
+        res.updateConfiguration(config, res.getDisplayMetrics());
     }
 }

--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -347,14 +347,27 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
         // Make sure TTFF is shown, if the TTFF is acquired before the mTTFFView is initialized
         mTTFFView.setText(mTtff);
 
-        boolean showDMS = Application.getPrefs().getBoolean(getString(R.string.pref_key_dms_mode), false);
-        if (showDMS) {
-            mLatitudeView.setText(UIUtils.getDMSFromLocation(Application.get(), location.getLatitude()));
-            mLongitudeView.setText(UIUtils.getDMSFromLocation(Application.get(), location.getLongitude()));
-        } else {
-            mLatitudeView.setText(mRes.getString(R.string.gps_latitude_value, location.getLatitude()));
-            mLongitudeView.setText(mRes.getString(R.string.gps_longitude_value, location.getLongitude()));
+        String gpsDisplayMode = Application.getPrefs().getString(getString(R.string.pref_key_preferred_display_mode), "dd");
+
+        switch (gpsDisplayMode) {
+            case "dd":
+                mLatitudeView.setText(mRes.getString(R.string.gps_latitude_value, location.getLatitude()));
+                mLongitudeView.setText(mRes.getString(R.string.gps_longitude_value, location.getLongitude()));
+                break;
+            case "dms":
+                mLatitudeView.setText(UIUtils.getDMSFromLocation(Application.get(), location.getLatitude(), "lat"));
+                mLongitudeView.setText(UIUtils.getDMSFromLocation(Application.get(), location.getLongitude(), "lon"));
+                break;
+            case "ddm":
+                mLatitudeView.setText(UIUtils.getDDMFromLocation(Application.get(), location.getLatitude(), "lat"));
+                mLongitudeView.setText(UIUtils.getDDMFromLocation(Application.get(), location.getLongitude(), "lon"));
+                break;
+            default:
+                mLatitudeView.setText(mRes.getString(R.string.gps_latitude_value, location.getLatitude()));
+                mLongitudeView.setText(mRes.getString(R.string.gps_longitude_value, location.getLongitude()));
+                break;
         }
+
         mFixTime = location.getTime();
 
         if (location.hasAltitude()) {

--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -347,22 +347,26 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
         // Make sure TTFF is shown, if the TTFF is acquired before the mTTFFView is initialized
         mTTFFView.setText(mTtff);
 
-        String gpsDisplayMode = Application.getPrefs().getString(getString(R.string.pref_key_preferred_display_mode), "dd");
-
-        switch (gpsDisplayMode) {
+        String coordinateFormat = Application.getPrefs().getString(getString(R.string.pref_key_coordinate_format), getString(R.string.preferences_coordinate_format_dd_key));
+        switch (coordinateFormat) {
+            // Constants below must match string values in do_not_translate.xml
             case "dd":
+                // Decimal degrees
                 mLatitudeView.setText(mRes.getString(R.string.gps_latitude_value, location.getLatitude()));
                 mLongitudeView.setText(mRes.getString(R.string.gps_longitude_value, location.getLongitude()));
                 break;
             case "dms":
-                mLatitudeView.setText(UIUtils.getDMSFromLocation(Application.get(), location.getLatitude(), "lat"));
-                mLongitudeView.setText(UIUtils.getDMSFromLocation(Application.get(), location.getLongitude(), "lon"));
+                // Degrees minutes seconds
+                mLatitudeView.setText(UIUtils.getDMSFromLocation(Application.get(), location.getLatitude(), UIUtils.COORDINATE_LATITUDE));
+                mLongitudeView.setText(UIUtils.getDMSFromLocation(Application.get(), location.getLongitude(), UIUtils.COORDINATE_LONGITUDE));
                 break;
             case "ddm":
-                mLatitudeView.setText(UIUtils.getDDMFromLocation(Application.get(), location.getLatitude(), "lat"));
-                mLongitudeView.setText(UIUtils.getDDMFromLocation(Application.get(), location.getLongitude(), "lon"));
+                // Degrees decimal minutes
+                mLatitudeView.setText(UIUtils.getDDMFromLocation(Application.get(), location.getLatitude(), UIUtils.COORDINATE_LATITUDE));
+                mLongitudeView.setText(UIUtils.getDDMFromLocation(Application.get(), location.getLongitude(), UIUtils.COORDINATE_LONGITUDE));
                 break;
             default:
+                // Decimal degrees
                 mLatitudeView.setText(mRes.getString(R.string.gps_latitude_value, location.getLatitude()));
                 mLongitudeView.setText(mRes.getString(R.string.gps_longitude_value, location.getLongitude()));
                 break;

--- a/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
@@ -299,17 +299,50 @@ public class UIUtils {
 
     /**
      * Returns the provided latitude or longitude value in Degrees Minutes Seconds (DMS) format
-     * @param latOrLon latitude or longitude to convert to DMS format
+     * @param coordinate latitude or longitude to convert to DMS format
      * @return the provided latitude or longitude value in Degrees Minutes Seconds (DMS) format
      */
-    public static String getDMSFromLocation(Context context, double latOrLon) {
-        BigDecimal loc = new BigDecimal(latOrLon);
+    public static String getDMSFromLocation(Context context, double coordinate, String latOrLon) {
+        BigDecimal loc = new BigDecimal(coordinate);
         BigDecimal degrees = loc.setScale(0, RoundingMode.DOWN);
         BigDecimal minTemp = loc.subtract(degrees).multiply((new BigDecimal(60))).abs();
         BigDecimal minutes = minTemp.setScale(0, RoundingMode.DOWN);
-        BigDecimal seconds = minTemp.subtract(minutes).multiply(new BigDecimal(60)).setScale(0, RoundingMode.DOWN);
+        BigDecimal seconds = minTemp.subtract(minutes).multiply(new BigDecimal(60)).setScale(2, RoundingMode.HALF_UP);
 
-        return context.getString(R.string.gps_lat_lon_dms_value, degrees.intValue(), minutes.intValue(), seconds.intValue());
+        String hemisphere;
+        int output_string;
+        if (latOrLon.equals("lat")) {
+            hemisphere = (coordinate < 0 ? "S" : "N");
+            output_string = R.string.gps_lat_dms_value;
+        } else {
+            hemisphere = (coordinate < 0 ? "W" : "E");
+            output_string = R.string.gps_lon_dms_value;
+        }
+
+        return context.getString(output_string, hemisphere, degrees.abs().intValue(), minutes.intValue(), seconds.floatValue());
+    }
+
+    /**
+     * Returns the provided latitude or longitude value in Decimal Degree Minutes (DDM) format
+     *
+     * @param coordinate latitude or longitude to convert to DDM format
+     * @param latOrLon   lat or lon to format hemisphere
+     * @return the provided latitude or longitude value in Decimal Degree Minutes (DDM) format
+     */
+    public static String getDDMFromLocation(Context context, double coordinate, String latOrLon) {
+        BigDecimal loc = new BigDecimal(coordinate);
+        BigDecimal degrees = loc.setScale(0, RoundingMode.DOWN);
+        BigDecimal minutes = loc.subtract(degrees).multiply((new BigDecimal(60))).abs().setScale(3, RoundingMode.HALF_UP);
+        String hemisphere;
+        int output_string;
+        if (latOrLon.equals("lat")) {
+            hemisphere = (coordinate < 0 ? "S" : "N");
+            output_string = R.string.gps_lat_ddm_value;
+        } else {
+            hemisphere = (coordinate < 0 ? "W" : "E");
+            output_string = R.string.gps_lon_ddm_value;
+        }
+        return context.getString(output_string, hemisphere, degrees.abs().intValue(), minutes.floatValue());
     }
 
     /**

--- a/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
@@ -56,6 +56,9 @@ import static com.android.gpstest.view.GpsSkyView.MIN_VALUE_SNR;
 
 public class UIUtils {
 
+    public static final String COORDINATE_LATITUDE = "lat";
+    public static final String COORDINATE_LONGITUDE = "lon";
+
     /**
      * Formats a view so it is ignored for accessible access
      */
@@ -311,7 +314,7 @@ public class UIUtils {
 
         String hemisphere;
         int output_string;
-        if (latOrLon.equals("lat")) {
+        if (latOrLon.equals(UIUtils.COORDINATE_LATITUDE)) {
             hemisphere = (coordinate < 0 ? "S" : "N");
             output_string = R.string.gps_lat_dms_value;
         } else {
@@ -335,7 +338,7 @@ public class UIUtils {
         BigDecimal minutes = loc.subtract(degrees).multiply((new BigDecimal(60))).abs().setScale(3, RoundingMode.HALF_UP);
         String hemisphere;
         int output_string;
-        if (latOrLon.equals("lat")) {
+        if (latOrLon.equals(COORDINATE_LATITUDE)) {
             hemisphere = (coordinate < 0 ? "S" : "N");
             output_string = R.string.gps_lat_ddm_value;
         } else {

--- a/GPSTest/src/main/res/values-ja/strings.xml
+++ b/GPSTest/src/main/res/values-ja/strings.xml
@@ -220,8 +220,6 @@
     <string name="pref_dark_theme_title">暗いテーマを使用する</string>
     <string name="pref_dark_theme_summary">背景に暗い色を、テキストに薄い色を付ける</string>
 
-    <string name="pref_dms_mode_title">DMS形式を使用する</string>
-    <string name="pref_dms_mode_summary">緯度と経度を度、分、秒で表示する</string>
 
     <string name="preferences_preferred_distance_units_title">距離単位</string>
     <string name="preferences_preferred_distance_units_option_meters">m</string>

--- a/GPSTest/src/main/res/values-nl/strings.xml
+++ b/GPSTest/src/main/res/values-nl/strings.xml
@@ -274,10 +274,7 @@
     <string name="pref_dark_theme_summary">Geef de achtergrond een donkere kleur en de tekst een lichte kleur.
 	</string>
 
-    <string name="pref_dms_mode_title">Gebruik GMS-formaat</string>
-    <string name="pref_dms_mode_summary">Toon de lengte- en breedtegraden in graden, minuten en seconden (GMS) in plaats van decimale graden (DG)</string>
-
-    <string name="preferences_preferred_distance_units_title">Voorkeurseenheid voor afstand</string>
+    <string name="preferences_preferred_distance_units_title">Voorkeurs afstandseenheden</string>
     <string name="preferences_preferred_distance_units_option_meters">Meters</string>
     <string name="preferences_preferred_distance_units_option_feet">Voeten</string>
 
@@ -363,9 +360,9 @@ heeft voor deze satelliet, (G) als de satelliet werd gebruikt in de berekening v
 
 <b>*** Nauwkeurigheids-weergave***\n\n&#8226;\u0020</b>
  <b>Vertical afwijking</b>
-- Verticale afwijking kan, anders dan horizontale afwijking, zowel positief als negatief zijn. Als de nauwkeurigheidsweergave wordt gebruikt zullen de absolute waardes van de verticale en gemiddelde afwijking worden gebruikt om de foutwaarden te berekenen.  
+- Verticale afwijking kan, anders dan horizontale afwijking, zowel positief als negatief zijn. Als de nauwkeurigheidsweergave wordt gebruikt zullen de absolute waardes van de verticale en gemiddelde afwijking worden gebruikt om de foutwaarden te berekenen.
 
-        
+
 <b>*** Erkenningen ***</b>\n\n
 &#8226;\u0020 <b>Mike Lockwood</b> - oorspronkelijke ontwikkelaar voor v1.x\n
 &#8226;\u0020 <b>Sean Barbeau</b> - ontwikkelaar voor v2.x en hoger\n

--- a/GPSTest/src/main/res/values/arrays.xml
+++ b/GPSTest/src/main/res/values/arrays.xml
@@ -37,6 +37,18 @@
         <item>Terrain View</item>
     </string-array>
 
+    <string-array name="preferred_display_mode_options">
+        <item>@string/preferences_preferred_display_mode_option_dd</item>
+        <item>@string/preferences_preferred_display_mode_option_dms</item>
+        <item>@string/preferences_preferred_display_mode_option_ddm</item>
+    </string-array>
+
+    <string-array name="preferred_display_mode_options_values">
+        <item>dd</item>
+        <item>dms</item>
+        <item>ddm</item>
+    </string-array>
+
     <!-- Help -->
     <string-array name="main_help_options">
         <item>What\'s New?</item>

--- a/GPSTest/src/main/res/values/arrays.xml
+++ b/GPSTest/src/main/res/values/arrays.xml
@@ -37,18 +37,6 @@
         <item>Terrain View</item>
     </string-array>
 
-    <string-array name="preferred_display_mode_options">
-        <item>@string/preferences_preferred_display_mode_option_dd</item>
-        <item>@string/preferences_preferred_display_mode_option_dms</item>
-        <item>@string/preferences_preferred_display_mode_option_ddm</item>
-    </string-array>
-
-    <string-array name="preferred_display_mode_options_values">
-        <item>dd</item>
-        <item>dms</item>
-        <item>ddm</item>
-    </string-array>
-
     <!-- Help -->
     <string-array name="main_help_options">
         <item>What\'s New?</item>

--- a/GPSTest/src/main/res/values/do_not_translate.xml
+++ b/GPSTest/src/main/res/values/do_not_translate.xml
@@ -25,6 +25,10 @@
     <string name="gps_latitude_value">%1$.7f\u00B0</string>
     <string name="gps_lat_lon_dms_value">%1$d\u00B0 %2$d\' %3$d\"</string>
     <string name="gps_longitude_value">%1$.7f\u00B0</string>
+    <string name="gps_lat_dms_value">%1$s\t\u2007%2$02d\u00B0 %3$2d\' %4$05.2f\"</string>
+    <string name="gps_lon_dms_value">%1$s\t%2$03d\u00B0 %3$2d\' %4$05.2f\"</string>
+    <string name="gps_lat_ddm_value">%1$s\t\u2007%2$02d\u00B0 %3$06.3f</string>
+    <string name="gps_lon_ddm_value">%1$s\t%2$03d\u00B0 %3$06.3f</string>
     <string name="gps_altitude_value_meters">%1$.1f m</string>
     <string name="gps_altitude_value_feet">%1$.1f ft</string>
     <string name="gps_altitude_msl_value_meters">%1$.1f m</string>
@@ -113,7 +117,8 @@
     <string name="pref_key_showed_v2_tutorial">showed_v2_tutorial</string>
     <string name="pref_key_dark_theme">dark_theme</string>
     <string name="pref_key_never_show_clear_assist_warning">never_show_clear_assist_warning</string>
-    <string name="pref_key_preferred_display_mode">display_mode</string>
+    <string name="pref_key_coordinate_format">coordinate_format</string>
+
     <string name="pref_key_never_show_qr_code_instructions">never_show_qr_code_instructions</string>
     <string name="pref_key_preferred_distance_units_v2">preference_distance_units_v2</string>
     <string name="pref_key_preferred_speed_units_v2">preference_speed_units_v2</string>
@@ -222,4 +227,22 @@
         <item>pl</item>
         <item>fr</item>
     </string-array>
+
+
+    <!-- Coordinate formats -->
+    <string-array name="preferred_coordinate_format_entries">
+        <item>@string/preferences_coordinate_format_dd</item>
+        <item>@string/preferences_coordinate_format_dms</item>
+        <item>@string/preferences_coordinate_format_ddm</item>
+    </string-array>
+
+    <string-array name="preferred_coordinate_format_values">
+        <item>@string/preferences_coordinate_format_dd_key</item>
+        <item>@string/preferences_coordinate_format_dms_key</item>
+        <item>@string/preferences_coordinate_format_ddm_key</item>
+    </string-array>
+
+    <string name="preferences_coordinate_format_dd_key">dd</string>
+    <string name="preferences_coordinate_format_dms_key">dms</string>
+    <string name="preferences_coordinate_format_ddm_key">ddm</string>
 </resources>

--- a/GPSTest/src/main/res/values/do_not_translate.xml
+++ b/GPSTest/src/main/res/values/do_not_translate.xml
@@ -113,8 +113,8 @@
     <string name="pref_key_showed_v2_tutorial">showed_v2_tutorial</string>
     <string name="pref_key_dark_theme">dark_theme</string>
     <string name="pref_key_never_show_clear_assist_warning">never_show_clear_assist_warning</string>
+    <string name="pref_key_preferred_display_mode">display_mode</string>
     <string name="pref_key_never_show_qr_code_instructions">never_show_qr_code_instructions</string>
-    <string name="pref_key_dms_mode">dms_mode</string>
     <string name="pref_key_preferred_distance_units_v2">preference_distance_units_v2</string>
     <string name="pref_key_preferred_speed_units_v2">preference_speed_units_v2</string>
     <string name="pref_key_language">preference_language</string>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -61,6 +61,10 @@
     <string name="mode_satellite">Satellite</string>
 
     <string name="gps_latitude_label">Lat:</string>
+    <string name="gps_lat_dms_value">%1$s\t\u2007%2$02d\u00B0 %3$2d\' %4$05.2f\"</string>
+    <string name="gps_lon_dms_value">%1$s\t%2$03d\u00B0 %3$2d\' %4$05.2f\"</string>
+    <string name="gps_lat_ddm_value">%1$s\t\u2007%2$02d\u00B0 %3$06.3f</string>
+    <string name="gps_lon_ddm_value">%1$s\t%2$03d\u00B0 %3$06.3f</string>
     <string name="gps_longitude_label">Long:</string>
     <string name="gps_fix_time_label">Time:</string>
     <string name="gps_ttff_label">TTFF:</string>
@@ -286,8 +290,11 @@
     <string name="pref_dark_theme_summary">Give the background a dark color and text a light color
     </string>
 
-    <string name="pref_dms_mode_title">Use DMS format</string>
-    <string name="pref_dms_mode_summary">Show latitude and longitude in degrees, minutes, and seconds instead of decimal degrees</string>
+    <string name="pref_preferred_coordinate_format_title">Coordinate format</string>
+    <string name="pref_preferred_coordinate_format_summary">Sets the display format of the GPS coordinates shown</string>
+    <string name="preferences_preferred_display_mode_option_dd">Decimal Degrees</string>
+    <string name="preferences_preferred_display_mode_option_dms">Degrees, Minutes, Decimal Seconds</string>
+    <string name="preferences_preferred_display_mode_option_ddm">Degrees, Decimal Minutes</string>
 
     <string name="preferences_preferred_distance_units_title">Preferred distance units</string>
     <string name="preferences_preferred_distance_units_option_meters">Meters</string>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -61,10 +61,6 @@
     <string name="mode_satellite">Satellite</string>
 
     <string name="gps_latitude_label">Lat:</string>
-    <string name="gps_lat_dms_value">%1$s\t\u2007%2$02d\u00B0 %3$2d\' %4$05.2f\"</string>
-    <string name="gps_lon_dms_value">%1$s\t%2$03d\u00B0 %3$2d\' %4$05.2f\"</string>
-    <string name="gps_lat_ddm_value">%1$s\t\u2007%2$02d\u00B0 %3$06.3f</string>
-    <string name="gps_lon_ddm_value">%1$s\t%2$03d\u00B0 %3$06.3f</string>
     <string name="gps_longitude_label">Long:</string>
     <string name="gps_fix_time_label">Time:</string>
     <string name="gps_ttff_label">TTFF:</string>
@@ -290,11 +286,11 @@
     <string name="pref_dark_theme_summary">Give the background a dark color and text a light color
     </string>
 
-    <string name="pref_preferred_coordinate_format_title">Coordinate format</string>
-    <string name="pref_preferred_coordinate_format_summary">Display GNSS coordinates in decimal degrees, DMS, or degrees minutes decimal seconds</string>
-    <string name="preferences_preferred_display_mode_option_dd">Decimal Degrees</string>
-    <string name="preferences_preferred_display_mode_option_dms">Degrees, Minutes, Decimal Seconds</string>
-    <string name="preferences_preferred_display_mode_option_ddm">Degrees, Decimal Minutes</string>
+    <string name="pref_coordinate_format_title">Coordinate format</string>
+    <string name="pref_coordinate_format_summary">Display in decimal degrees, DMS, or degrees decimal minutes</string>
+    <string name="preferences_coordinate_format_dd">Decimal Degrees</string>
+    <string name="preferences_coordinate_format_dms">Degrees, Minutes, Decimal Seconds</string>
+    <string name="preferences_coordinate_format_ddm">Degrees, Decimal Minutes</string>
 
     <string name="preferences_preferred_distance_units_title">Preferred distance units</string>
     <string name="preferences_preferred_distance_units_option_meters">Meters</string>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -291,7 +291,7 @@
     </string>
 
     <string name="pref_preferred_coordinate_format_title">Coordinate format</string>
-    <string name="pref_preferred_coordinate_format_summary">Sets the display format of the GPS coordinates shown</string>
+    <string name="pref_preferred_coordinate_format_summary">Display GNSS coordinates in decimal degrees, DMS, or degrees minutes decimal seconds</string>
     <string name="preferences_preferred_display_mode_option_dd">Decimal Degrees</string>
     <string name="preferences_preferred_display_mode_option_dms">Degrees, Minutes, Decimal Seconds</string>
     <string name="preferences_preferred_display_mode_option_ddm">Degrees, Decimal Minutes</string>

--- a/GPSTest/src/main/res/xml/preferences.xml
+++ b/GPSTest/src/main/res/xml/preferences.xml
@@ -26,11 +26,14 @@
             android:title="@string/pref_true_north_title"
             android:summary="@string/pref_true_north_summary"
             android:defaultValue="true" />
-        <CheckBoxPreference
-            android:key="@string/pref_key_dms_mode"
-            android:title="@string/pref_dms_mode_title"
-            android:summary="@string/pref_dms_mode_summary"
-            android:defaultValue="false" />
+        <ListPreference
+            android:key="@string/pref_key_preferred_display_mode"
+            android:title="@string/pref_preferred_coordinate_format_title"
+            android:summary="@string/pref_preferred_coordinate_format_summary"
+            android:dialogTitle="@string/pref_preferred_coordinate_format_title"
+            android:entries="@array/preferred_display_mode_options"
+            android:entryValues="@array/preferred_display_mode_options_values"
+            android:defaultValue="dd"></ListPreference>
         <ListPreference
             android:key="@string/pref_key_preferred_distance_units_v2"
             android:title="@string/preferences_preferred_distance_units_title"

--- a/GPSTest/src/main/res/xml/preferences.xml
+++ b/GPSTest/src/main/res/xml/preferences.xml
@@ -27,13 +27,13 @@
             android:summary="@string/pref_true_north_summary"
             android:defaultValue="true" />
         <ListPreference
-            android:key="@string/pref_key_preferred_display_mode"
-            android:title="@string/pref_preferred_coordinate_format_title"
-            android:summary="@string/pref_preferred_coordinate_format_summary"
-            android:dialogTitle="@string/pref_preferred_coordinate_format_title"
-            android:entries="@array/preferred_display_mode_options"
-            android:entryValues="@array/preferred_display_mode_options_values"
-            android:defaultValue="dd"></ListPreference>
+            android:key="@string/pref_key_coordinate_format"
+            android:title="@string/pref_coordinate_format_title"
+            android:summary="@string/pref_coordinate_format_summary"
+            android:dialogTitle="@string/pref_coordinate_format_title"
+            android:entries="@array/preferred_coordinate_format_entries"
+            android:entryValues="@array/preferred_coordinate_format_values"
+            android:defaultValue="@string/preferences_coordinate_format_dd_key" />
         <ListPreference
             android:key="@string/pref_key_preferred_distance_units_v2"
             android:title="@string/preferences_preferred_distance_units_title"


### PR DESCRIPTION
This is a version of https://github.com/barbeau/gpstest/pull/243 merged with the master branch, which I'll use to finish off this feature.

TODO:
- [x] Address comments in https://github.com/barbeau/gpstest/pull/243
- [x] Fix unit tests to work on multiple locales
- [x] Remove leading `0` from coordinates for DMS and DDM - **EDIT** Per https://github.com/barbeau/gpstest/pull/243#issuecomment-449610727 leaving it was intentional