### PR TITLE
Fix #324 - Limit feedback to email apps

### DIFF
--- a/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
@@ -294,14 +294,15 @@ public class UIUtils {
 
         body.append("\n\n\n");
 
-        Intent send = new Intent(Intent.ACTION_SEND);
+        Intent send = new Intent(Intent.ACTION_SENDTO);
+        send.setData(Uri.parse("mailto:"));
         send.putExtra(Intent.EXTRA_EMAIL, new String[]{email});
 
         String subject = context.getString(R.string.feedback_subject);
 
         send.putExtra(Intent.EXTRA_SUBJECT, subject);
         send.putExtra(Intent.EXTRA_TEXT, body.toString());
-        send.setType("message/rfc822");
+
         try {
             context.startActivity(createChooser(send, subject));
         } catch (ActivityNotFoundException e) {


### PR DESCRIPTION
Allow users to select an email app to send feedback through, while removing apps which do not explicitly handle the `mailto` URI.

Technically this will still allow the selection of non-email clients (👀 PayPal), but it will reduce the app selection to more reasonable options. There is no way of excluding apps which hijack URIs, so this is the next best thing.

---

Setting the MIME type to `message/rfc822` does not seem to be compatible with the `mailto` URL, resulting in an empty intent picker.
Using the `ACTION_SEND` intent does not seem to be compatible with the `mailto` URI, but this is undocumented _AFAIK_.

---

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Acknowledge that you're contributing your code under Apache v2.0 license

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.