### PR TITLE
Manually install JDK and Android SDK on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,112 @@
-language: android
+sudo: true
+language: bash
+# ignored on non-linux platforms, but bionic is required for nested virtualization
+dist: bionic
 
-jdk:
-- oraclejdk8
+stages:
+  - install
+  - test
+  - cache
+
+env:
+  global:
+    - BUILD_TOOLS=28.0.3
+    - COMPILE_SDK_VERSION=28
+    - ABI=x86_64
+    - ADB_INSTALL_TIMEOUT=8
+    - ANDROID_HOME=${HOME}/android-sdk
+    - ANDROID_TOOLS_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
+    - EMU_FLAVOR=default # use google_apis flavor if no default flavor emulator
+    - GRAVIS="https://raw.githubusercontent.com/DanySK/Gravis-CI/master/"
+    - JDK="1.8"
+    - TOOLS=${ANDROID_HOME}/tools
+    # PATH order is incredibly important. e.g. the 'emulator' script exists in more than one place!
+    - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
+  matrix:
+    # - API=15 ABI=x86 EMU_CHANNEL="--channel=4" # ERROR: failed to start emulator
+    # - API=16 ABI=x86 AUDIO=-no-audio # ERROR: fails with com.android.ddmlib.InstallException: Unknown failure: Error: Unknown option: -d
+    - API=17 ABI=x86 # Works
+    - API=18 ABI=x86 # Works
+    - API=19 ABI=x86 # Works
+    # API 20 was Android Wear only
+    - API=21 ABI=x86_64 # Works
+    - API=22 ABI=x86_64 # Works
+    - API=23 ABI=x86_64 # Works
+    - API=24 ABI=x86_64 # Works
+    - API=25 ABI=x86_64 # Works
+    - API=26 ABI=x86_64 # Works
+    - API=27 ABI=x86_64 # Works
+    - API=28 ABI=x86_64 # Works
+    - API=29 ABI=x86_64 # Works
 
 before_install:
-# Install SDK license so Android Gradle plugin can install deps.
-- mkdir "$ANDROID_HOME/licenses" || true
-- echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
-- echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" >> "$ANDROID_HOME/licenses/android-sdk-license"
-# Install the rest of tools (e.g., avdmanager)
-- sdkmanager tools
-# Install the system image
-- sdkmanager "system-images;android-18;default;armeabi-v7a"
-# Create and start emulator for the script. Meant to race the install task.
-- echo no | avdmanager create avd --force -n test -k "system-images;android-18;default;armeabi-v7a"
-- $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
+  # This section may run on all platforms, and may run for unit tests or for coverage finalization
+  # It should not make assumptions about os platform or desired tool installation
 
-install: ./gradlew clean assembleDebug assembleAndroidTest -x lint --stacktrace
+  # Set up JDK 8 for Android SDK - Java is universally needed: codacy, unit tests, emulators
+  - curl "${GRAVIS}.install-jdk-travis.sh" --output ~/.install-jdk-travis.sh
+  - export TARGET_JDK="${JDK}"
+  - JDK="1.8"
+  - source ~/.install-jdk-travis.sh
 
-before_script:
-- android-wait-for-emulator
-- adb shell input keyevent 82
+  # Set up Android SDK - this is needed everywhere but coverage finalization
+  - wget -q "${ANDROID_TOOLS_URL}" -O android-sdk-tools.zip
+  - unzip -q android-sdk-tools.zip -d ${ANDROID_HOME}
+  - rm android-sdk-tools.zip
+  - mkdir ~/.android # avoid harmless sdkmanager warning
+  - echo 'count=0' > ~/.android/repositories.cfg # avoid harmless sdkmanager warning
+  - yes | sdkmanager --licenses >/dev/null # accept all sdkmanager warnings
+  - echo y | sdkmanager --no_https "platform-tools" >/dev/null
+  - echo y | sdkmanager --no_https "tools" >/dev/null # A second time per Travis docs, gets latest versions
+  - echo y | sdkmanager --no_https "build-tools;$BUILD_TOOLS" >/dev/null # Implicit gradle dependency - gradle drives changes
+  - echo y | sdkmanager --no_https "platforms;android-$COMPILE_SDK_VERSION" >/dev/null # We need the API of the current compileSdkVersion from gradle.properties
 
-script: ./gradlew test check connectedCheck -x lint --stacktrace
+install:
+  # In our setup, install only runs on matrix entries we want full emulator tests on
+  # That only happens currently on linux, so this section can assume linux + emulator is desired
+  # Download required emulator tools
+  - echo y | sdkmanager --no_https "platforms;android-$API" >/dev/null # We need the API of the emulator we will run
+  - echo y | sdkmanager --no_https "emulator" >/dev/null
+  - echo y | sdkmanager --no_https "system-images;android-$API;$EMU_FLAVOR;$ABI" >/dev/null # install our emulator
 
-branches:
-  except:
-  - gh-pages
+  # Set up KVM on linux for hardware acceleration. Manually here so it only happens for emulator tests, takes ~30s
+  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install bridge-utils libpulse0 libvirt-bin qemu-kvm virtinst ubuntu-vm-builder
+  - sudo adduser $USER libvirt
+  - sudo adduser $USER kvm
+
+  # Create an Android emulator
+  - echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI" -c 10M
+  - |
+    EMU_PARAMS="-verbose -no-snapshot -no-window -gpu swiftshader_indirect -camera-back none -camera-front none -selinux permissive -qemu -m 2048"
+    EMU_COMMAND="emulator"
+    # This double "sudo" monstrosity is used to have Travis execute the
+    # emulator with its new group permissions and help preserve the rule
+    # of least privilege.
+    sudo -E sudo -u $USER -E bash -c "${ANDROID_HOME}/emulator/${EMU_COMMAND} -avd test ${AUDIO} ${EMU_PARAMS} &"
+  # Wait for emulator to be ready
+  - ./tools/android-wait-for-emulator.sh
+  - adb shell input keyevent 82 &
+
+  # Switch back to our target JDK version to build and run tests
+  - JDK="${TARGET_JDK}"
+  - source ~/.install-jdk-travis.sh
+
+script:
+  - if [ "$API" != "NONE" ]; then ./gradlew test check connectedCheck -x lint --stacktrace; fi
+
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+  - curl "${GRAVIS}.clean_gradle_cache.sh" --output ~/.clean_gradle_cache.sh
+  - bash ~/.clean_gradle_cache.sh > /dev/null
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 
 notifications:
   email: false
 
-sudo: false
-
-before_cache:
-- rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-- rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-
-cache:
-  directories:
-  - $HOME/.gradle/caches/
-  - $HOME/.gradle/wrapper/
-  - $HOME/.android/build-cache
-
 # Transifex client configuration - https://docs.transifex.com/integrations/github#section-integrating-with-travis-ci
 after_success:
-- ./scripts/push-to-transifex.sh
+  - ./scripts/push-to-transifex.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ env:
     # PATH order is incredibly important. e.g. the 'emulator' script exists in more than one place!
     - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
   matrix:
-    # - API=15 ABI=x86 EMU_CHANNEL="--channel=4" # ERROR: failed to start emulator
-    # - API=16 ABI=x86 AUDIO=-no-audio # ERROR: fails with com.android.ddmlib.InstallException: Unknown failure: Error: Unknown option: -d
-    - API=17 ABI=x86 # Works
     - API=18 ABI=x86 # Works
     - API=19 ABI=x86 # Works
     # API 20 was Android Wear only

--- a/tools/android-wait-for-emulator.sh
+++ b/tools/android-wait-for-emulator.sh
@@ -1,0 +1,26 @@
+
+#!/bin/bash
+
+# Originally written by Ralf Kistner <ralf@embarkmobile.com>, but placed in the public domain
+
+set +e
+
+bootanim=""
+failcounter=0
+timeout_in_sec=600 # 10 minutes
+
+until [[ "$bootanim" =~ "stopped" ]]; do
+  bootanim=`adb -e shell getprop init.svc.bootanim 2>&1 &`
+  if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
+    || "$bootanim" =~ "running" || "$bootanim" =~  "error: no emulators found" ]]; then
+    let "failcounter += 1"
+    echo "Waiting for emulator to start"
+    if [[ $failcounter -gt timeout_in_sec ]]; then
+      echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
+      exit 1
+    fi
+  fi
+  sleep 1
+done
+
+echo "Emulator is ready"


### PR DESCRIPTION
Based on https://github.com/googlemaps/android-maps-utils/pull/590.

This allows us to use higher level API emulator versions (we're currently stuck on 18).