### PR TITLE
Fix #365 - Use C/N0 values when counting signals/sats in view

### DIFF
--- a/GPSTest/src/androidTest/java/com/android/gpstest/DeviceInfoViewModelTest.kt
+++ b/GPSTest/src/androidTest/java/com/android/gpstest/DeviceInfoViewModelTest.kt
@@ -49,10 +49,28 @@ class DeviceInfoViewModelTest {
         assertFalse(modelGpsL1.isNonPrimaryCarrierFreqInUse)
         assertFalse(modelGpsL1.isDualFrequencyPerSatInView)
         assertFalse(modelGpsL1.isDualFrequencyPerSatInUse)
-        assertEquals(1, modelGpsL1.numSatsUsedInViewPair.value?.second) // In view
-        assertEquals(1, modelGpsL1.numSatsUsedInViewPair.value?.first) // Used
-        assertEquals(1, modelGpsL1.numSignalsUsedInViewPair.value?.second) // In view
-        assertEquals(1, modelGpsL1.numSignalsUsedInViewPair.value?.first) // Used
+        assertEquals(1, modelGpsL1.satelliteMetadata.value?.numSatsInView)
+        assertEquals(1, modelGpsL1.satelliteMetadata.value?.numSatsUsed)
+        assertEquals(1, modelGpsL1.satelliteMetadata.value?.numSatsTotal)
+        assertEquals(1, modelGpsL1.satelliteMetadata.value?.numSignalsInView)
+        assertEquals(1, modelGpsL1.satelliteMetadata.value?.numSignalsUsed)
+        assertEquals(1, modelGpsL1.satelliteMetadata.value?.numSignalsTotal)
+
+        modelGpsL1.reset();
+
+        // Test GPS L1 no signal - should be 1 satellite, no L5 or dual-frequency
+        modelGpsL1.setStatuses(listOf(gpsL1NoSignal(1)), null)
+        assertEquals(1, modelGpsL1.gnssSatellites.value?.size)
+        assertFalse(modelGpsL1.isNonPrimaryCarrierFreqInView)
+        assertFalse(modelGpsL1.isNonPrimaryCarrierFreqInUse)
+        assertFalse(modelGpsL1.isDualFrequencyPerSatInView)
+        assertFalse(modelGpsL1.isDualFrequencyPerSatInUse)
+        assertEquals(0, modelGpsL1.satelliteMetadata.value?.numSatsInView)
+        assertEquals(0, modelGpsL1.satelliteMetadata.value?.numSatsUsed)
+        assertEquals(1, modelGpsL1.satelliteMetadata.value?.numSatsTotal)
+        assertEquals(0, modelGpsL1.satelliteMetadata.value?.numSignalsInView)
+        assertEquals(0, modelGpsL1.satelliteMetadata.value?.numSignalsUsed)
+        assertEquals(1, modelGpsL1.satelliteMetadata.value?.numSignalsTotal)
 
         // Test GPS L1 + L5 same sv - should be 1 satellite, dual frequency in view and but not in use
         val modelGpsL1L5 = DeviceInfoViewModel(InstrumentationRegistry.getTargetContext().applicationContext as Application)
@@ -63,10 +81,12 @@ class DeviceInfoViewModelTest {
             assertTrue(modelGpsL1L5.isNonPrimaryCarrierFreqInUse)
             assertTrue(modelGpsL1L5.isDualFrequencyPerSatInView)
             assertFalse(modelGpsL1L5.isDualFrequencyPerSatInUse)
-            assertEquals(1, modelGpsL1L5.numSatsUsedInViewPair.value?.second) // In view
-            assertEquals(1, modelGpsL1L5.numSatsUsedInViewPair.value?.first) // Used
-            assertEquals(2, modelGpsL1L5.numSignalsUsedInViewPair.value?.second) // In view
-            assertEquals(1, modelGpsL1L5.numSignalsUsedInViewPair.value?.first) // Used
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsInView)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsTotal)
         } else {
             assertFalse(modelGpsL1L5.isNonPrimaryCarrierFreqInView)
             assertFalse(modelGpsL1L5.isNonPrimaryCarrierFreqInUse)
@@ -86,10 +106,12 @@ class DeviceInfoViewModelTest {
             assertTrue(modelGpsL1L5.isNonPrimaryCarrierFreqInUse)
             assertTrue(modelGpsL1L5.isDualFrequencyPerSatInView)
             assertTrue(modelGpsL1L5.isDualFrequencyPerSatInUse)
-            assertEquals(1, modelGpsL1L5.numSatsUsedInViewPair.value?.second) // In view
-            assertEquals(1, modelGpsL1L5.numSatsUsedInViewPair.value?.first) // Used
-            assertEquals(2, modelGpsL1L5.numSignalsUsedInViewPair.value?.second) // In view
-            assertEquals(2, modelGpsL1L5.numSignalsUsedInViewPair.value?.first) // Used
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsInView)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsTotal)
         } else {
             assertFalse(modelGpsL1L5.isNonPrimaryCarrierFreqInView)
             assertFalse(modelGpsL1L5.isNonPrimaryCarrierFreqInUse)
@@ -109,10 +131,12 @@ class DeviceInfoViewModelTest {
             assertFalse(modelGpsL1L5.isNonPrimaryCarrierFreqInUse)
             assertTrue(modelGpsL1L5.isDualFrequencyPerSatInView)
             assertFalse(modelGpsL1L5.isDualFrequencyPerSatInUse)
-            assertEquals(1, modelGpsL1L5.numSatsUsedInViewPair.value?.second) // In view
-            assertEquals(1, modelGpsL1L5.numSatsUsedInViewPair.value?.first) // Used
-            assertEquals(2, modelGpsL1L5.numSignalsUsedInViewPair.value?.second) // In view
-            assertEquals(1, modelGpsL1L5.numSignalsUsedInViewPair.value?.first) // Used
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsInView)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsTotal)
         } else {
             assertFalse(modelGpsL1L5.isNonPrimaryCarrierFreqInView)
             assertFalse(modelGpsL1L5.isNonPrimaryCarrierFreqInUse)
@@ -132,19 +156,48 @@ class DeviceInfoViewModelTest {
             assertTrue(modelGpsL1L5.isNonPrimaryCarrierFreqInUse)
             assertFalse(modelGpsL1L5.isDualFrequencyPerSatInView)
             assertFalse(modelGpsL1L5.isDualFrequencyPerSatInUse)
-            assertEquals(2, modelGpsL1L5.numSatsUsedInViewPair.value?.second) // In view
-            assertEquals(2, modelGpsL1L5.numSatsUsedInViewPair.value?.first) // Used
-            assertEquals(2, modelGpsL1L5.numSignalsUsedInViewPair.value?.second) // In view
-            assertEquals(2, modelGpsL1L5.numSignalsUsedInViewPair.value?.first) // Used
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSatsInView)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsTotal)
         } else {
             assertFalse(modelGpsL1L5.isNonPrimaryCarrierFreqInView)
             assertFalse(modelGpsL1L5.isNonPrimaryCarrierFreqInUse)
             assertFalse(modelGpsL1L5.isDualFrequencyPerSatInView)
             assertFalse(modelGpsL1L5.isDualFrequencyPerSatInUse)
-            assertEquals(2, modelGpsL1L5.numSatsUsedInViewPair.value?.second) // In view
-            assertEquals(2, modelGpsL1L5.numSatsUsedInViewPair.value?.first) // Used
-            assertEquals(2, modelGpsL1L5.numSignalsUsedInViewPair.value?.second) // In view
-            assertEquals(2, modelGpsL1L5.numSignalsUsedInViewPair.value?.first) // Used
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSatsInView)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsTotal)
+        }
+
+        modelGpsL1L5.reset();
+
+        // Test GPS L1 + L5 same sv, but no L1 signal - should be 1 satellite, dual-frequency not in view or in use
+        modelGpsL1L5.setStatuses(listOf(gpsL1NoSignal(1), gpsL5(1, true)), null)
+        assertEquals(1, modelGpsL1L5.gnssSatellites.value?.size)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            assertTrue(modelGpsL1L5.isNonPrimaryCarrierFreqInView)
+            assertTrue(modelGpsL1L5.isNonPrimaryCarrierFreqInUse)
+            assertFalse(modelGpsL1L5.isDualFrequencyPerSatInView)
+            assertFalse(modelGpsL1L5.isDualFrequencyPerSatInUse)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsInView)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(1, modelGpsL1L5.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(2, modelGpsL1L5.satelliteMetadata.value?.numSignalsTotal)
+        } else {
+            assertFalse(modelGpsL1L5.isNonPrimaryCarrierFreqInView)
+            assertFalse(modelGpsL1L5.isNonPrimaryCarrierFreqInUse)
+            assertFalse(modelGpsL1L5.isDualFrequencyPerSatInView)
+            assertFalse(modelGpsL1L5.isDualFrequencyPerSatInUse)
+            // Because carrier frequency isn't considered, these signals should be detected as duplicates
+            assertEquals(1, modelGpsL1L5.duplicateCarrierStatuses.size)
         }
 
         modelGpsL1L5.reset();
@@ -158,19 +211,23 @@ class DeviceInfoViewModelTest {
             assertFalse(modelGpsL5.isNonPrimaryCarrierFreqInUse)
             assertFalse(modelGpsL5.isDualFrequencyPerSatInView)
             assertFalse(modelGpsL5.isDualFrequencyPerSatInUse)
-            assertEquals(1, modelGpsL5.numSatsUsedInViewPair.value?.second) // In view
-            assertEquals(0, modelGpsL5.numSatsUsedInViewPair.value?.first) // Used
-            assertEquals(1, modelGpsL5.numSignalsUsedInViewPair.value?.second) // In view
-            assertEquals(0, modelGpsL5.numSignalsUsedInViewPair.value?.first) // Used
+            assertEquals(1, modelGpsL5.satelliteMetadata.value?.numSatsInView)
+            assertEquals(0, modelGpsL5.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(1, modelGpsL5.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(1, modelGpsL5.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(0, modelGpsL5.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(1, modelGpsL5.satelliteMetadata.value?.numSignalsTotal)
         } else {
             assertFalse(modelGpsL5.isNonPrimaryCarrierFreqInView)
             assertFalse(modelGpsL5.isNonPrimaryCarrierFreqInUse)
             assertFalse(modelGpsL5.isDualFrequencyPerSatInView)
             assertFalse(modelGpsL5.isDualFrequencyPerSatInUse)
-            assertEquals(1, modelGpsL5.numSatsUsedInViewPair.value?.second) // In view
-            assertEquals(0, modelGpsL5.numSatsUsedInViewPair.value?.first) // Used
-            assertEquals(1, modelGpsL5.numSignalsUsedInViewPair.value?.second) // In view
-            assertEquals(0, modelGpsL5.numSignalsUsedInViewPair.value?.first) // Used
+            assertEquals(1, modelGpsL5.satelliteMetadata.value?.numSatsInView)
+            assertEquals(0, modelGpsL5.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(1, modelGpsL5.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(1, modelGpsL5.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(0, modelGpsL5.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(1, modelGpsL5.satelliteMetadata.value?.numSignalsTotal)
         }
 
         // Test GPS L1 + GLONASS L1 - should be 2 satellites, no non-primary carrier of dual-freq
@@ -181,10 +238,12 @@ class DeviceInfoViewModelTest {
         assertFalse(modelGpsL1GlonassL1.isNonPrimaryCarrierFreqInUse)
         assertFalse(modelGpsL1GlonassL1.isDualFrequencyPerSatInView)
         assertFalse(modelGpsL1GlonassL1.isDualFrequencyPerSatInUse)
-        assertEquals(2, modelGpsL1GlonassL1.numSatsUsedInViewPair.value?.second) // In view
-        assertEquals(2, modelGpsL1GlonassL1.numSatsUsedInViewPair.value?.first) // Used
-        assertEquals(2, modelGpsL1GlonassL1.numSignalsUsedInViewPair.value?.second) // In view
-        assertEquals(2, modelGpsL1GlonassL1.numSignalsUsedInViewPair.value?.first) // Used
+        assertEquals(2, modelGpsL1GlonassL1.satelliteMetadata.value?.numSatsInView)
+        assertEquals(2, modelGpsL1GlonassL1.satelliteMetadata.value?.numSatsUsed)
+        assertEquals(2, modelGpsL1GlonassL1.satelliteMetadata.value?.numSatsTotal)
+        assertEquals(2, modelGpsL1GlonassL1.satelliteMetadata.value?.numSignalsInView)
+        assertEquals(2, modelGpsL1GlonassL1.satelliteMetadata.value?.numSignalsUsed)
+        assertEquals(2, modelGpsL1GlonassL1.satelliteMetadata.value?.numSignalsTotal)
 
         // Test Galileo E1 + E5a - should be 2 satellites, dual frequency not in use, non-primary carrier of dual-freq
         val modelGalileoE1E5a = DeviceInfoViewModel(InstrumentationRegistry.getTargetContext().applicationContext as Application)
@@ -195,19 +254,23 @@ class DeviceInfoViewModelTest {
             assertTrue(modelGalileoE1E5a.isNonPrimaryCarrierFreqInUse)
             assertFalse(modelGalileoE1E5a.isDualFrequencyPerSatInView)
             assertFalse(modelGalileoE1E5a.isDualFrequencyPerSatInUse)
-            assertEquals(2, modelGalileoE1E5a.numSatsUsedInViewPair.value?.second) // In view
-            assertEquals(2, modelGalileoE1E5a.numSatsUsedInViewPair.value?.first) // Used
-            assertEquals(2, modelGalileoE1E5a.numSignalsUsedInViewPair.value?.second) // In view
-            assertEquals(2, modelGalileoE1E5a.numSignalsUsedInViewPair.value?.first) // Used
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSatsInView)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSignalsTotal)
         } else {
             assertFalse(modelGalileoE1E5a.isNonPrimaryCarrierFreqInView)
             assertFalse(modelGalileoE1E5a.isNonPrimaryCarrierFreqInUse)
             assertFalse(modelGalileoE1E5a.isDualFrequencyPerSatInView)
             assertFalse(modelGalileoE1E5a.isDualFrequencyPerSatInUse)
-            assertEquals(2, modelGalileoE1E5a.numSatsUsedInViewPair.value?.second) // In view
-            assertEquals(2, modelGalileoE1E5a.numSatsUsedInViewPair.value?.first) // Used
-            assertEquals(2, modelGalileoE1E5a.numSignalsUsedInViewPair.value?.second) // In view
-            assertEquals(2, modelGalileoE1E5a.numSignalsUsedInViewPair.value?.first) // Used
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSatsInView)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSignalsTotal)
         }
 
         modelGalileoE1E5a.reset()
@@ -220,10 +283,12 @@ class DeviceInfoViewModelTest {
             assertTrue(modelGalileoE1E5a.isNonPrimaryCarrierFreqInUse)
             assertTrue(modelGalileoE1E5a.isDualFrequencyPerSatInView)
             assertTrue(modelGalileoE1E5a.isDualFrequencyPerSatInUse)
-            assertEquals(1, modelGalileoE1E5a.numSatsUsedInViewPair.value?.second) // In view
-            assertEquals(1, modelGalileoE1E5a.numSatsUsedInViewPair.value?.first) // Used
-            assertEquals(2, modelGalileoE1E5a.numSignalsUsedInViewPair.value?.second) // In view
-            assertEquals(2, modelGalileoE1E5a.numSignalsUsedInViewPair.value?.first) // Used
+            assertEquals(1, modelGalileoE1E5a.satelliteMetadata.value?.numSatsInView)
+            assertEquals(1, modelGalileoE1E5a.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(1, modelGalileoE1E5a.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(2, modelGalileoE1E5a.satelliteMetadata.value?.numSignalsTotal)
         } else {
             assertFalse(modelGalileoE1E5a.isNonPrimaryCarrierFreqInView)
             assertFalse(modelGalileoE1E5a.isNonPrimaryCarrierFreqInUse)
@@ -243,10 +308,12 @@ class DeviceInfoViewModelTest {
         assertFalse(modelWaasL1L5.isNonPrimaryCarrierFreqInUse)
         assertFalse(modelWaasL1L5.isDualFrequencyPerSatInView)
         assertFalse(modelWaasL1L5.isDualFrequencyPerSatInUse)
-        assertEquals(1, modelWaasL1L5.numSatsUsedInViewPair.value?.second) // In view
-        assertEquals(1, modelWaasL1L5.numSatsUsedInViewPair.value?.first) // Used
-        assertEquals(1, modelWaasL1L5.numSignalsUsedInViewPair.value?.second) // In view
-        assertEquals(1, modelWaasL1L5.numSignalsUsedInViewPair.value?.first) // Used
+        assertEquals(1, modelWaasL1L5.satelliteMetadata.value?.numSatsInView)
+        assertEquals(1, modelWaasL1L5.satelliteMetadata.value?.numSatsUsed)
+        assertEquals(1, modelWaasL1L5.satelliteMetadata.value?.numSatsTotal)
+        assertEquals(1, modelWaasL1L5.satelliteMetadata.value?.numSignalsInView)
+        assertEquals(1, modelWaasL1L5.satelliteMetadata.value?.numSignalsUsed)
+        assertEquals(1, modelWaasL1L5.satelliteMetadata.value?.numSignalsTotal)
 
         modelWaasL1L5.reset()
 
@@ -258,10 +325,12 @@ class DeviceInfoViewModelTest {
             assertTrue(modelWaasL1L5.isNonPrimaryCarrierFreqInUse)
             assertTrue(modelWaasL1L5.isDualFrequencyPerSatInView)
             assertTrue(modelWaasL1L5.isDualFrequencyPerSatInUse)
-            assertEquals(1, modelWaasL1L5.numSatsUsedInViewPair.value?.second) // In view
-            assertEquals(1, modelWaasL1L5.numSatsUsedInViewPair.value?.first) // Used
-            assertEquals(2, modelWaasL1L5.numSignalsUsedInViewPair.value?.second) // In view
-            assertEquals(2, modelWaasL1L5.numSignalsUsedInViewPair.value?.first) // Used
+            assertEquals(1, modelWaasL1L5.satelliteMetadata.value?.numSatsInView)
+            assertEquals(1, modelWaasL1L5.satelliteMetadata.value?.numSatsUsed)
+            assertEquals(1, modelWaasL1L5.satelliteMetadata.value?.numSatsTotal)
+            assertEquals(2, modelWaasL1L5.satelliteMetadata.value?.numSignalsInView)
+            assertEquals(2, modelWaasL1L5.satelliteMetadata.value?.numSignalsUsed)
+            assertEquals(2, modelWaasL1L5.satelliteMetadata.value?.numSignalsTotal)
         } else {
             assertFalse(modelWaasL1L5.isNonPrimaryCarrierFreqInView)
             assertFalse(modelWaasL1L5.isNonPrimaryCarrierFreqInUse)

--- a/GPSTest/src/androidTest/java/com/android/gpstest/TestUtils.kt
+++ b/GPSTest/src/androidTest/java/com/android/gpstest/TestUtils.kt
@@ -17,6 +17,7 @@ package com.android.gpstest
 
 import com.android.gpstest.model.GnssType
 import com.android.gpstest.model.SatelliteStatus
+import com.android.gpstest.model.SatelliteStatus.Companion.NO_DATA
 import com.android.gpstest.model.SbasType
 
 /**
@@ -31,6 +32,23 @@ fun gpsL1(id: Int, usedInFix: Boolean): SatelliteStatus {
             usedInFix,
             72f,
             25f);
+    gpsL1.hasCarrierFrequency = true
+    gpsL1.carrierFrequencyHz = 1575420000.0f
+    return gpsL1
+}
+
+/**
+ * Returns a status for a GPS NAVSTAR L1 signal, but with no C/N0 data
+ */
+fun gpsL1NoSignal(id: Int): SatelliteStatus {
+    val gpsL1 = SatelliteStatus(id,
+            GnssType.NAVSTAR,
+            NO_DATA,
+            false,
+            false,
+            false,
+            NO_DATA,
+            NO_DATA);
     gpsL1.hasCarrierFrequency = true
     gpsL1.carrierFrequencyHz = 1575420000.0f
     return gpsL1

--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -46,7 +46,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AlertDialog;
 import androidx.cardview.widget.CardView;
-import androidx.core.util.Pair;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProviders;
@@ -56,6 +55,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.android.gpstest.model.ConstellationType;
 import com.android.gpstest.model.DilutionOfPrecision;
 import com.android.gpstest.model.GnssType;
+import com.android.gpstest.model.SatelliteMetadata;
 import com.android.gpstest.model.SatelliteStatus;
 import com.android.gpstest.util.CarrierFreqUtils;
 import com.android.gpstest.util.IOUtils;
@@ -136,17 +136,16 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
 
     DeviceInfoViewModel mViewModel;
 
-    private final Observer<Pair<Integer, Integer>> mNumSatsObserver = new Observer<Pair<Integer, Integer>>() {
+    private final Observer<SatelliteMetadata> mSatelliteMetadataObserver = new Observer<SatelliteMetadata>() {
         @Override
-        public void onChanged(@Nullable final Pair<Integer, Integer> numSatsUsedInViewPair) {
-            if (numSatsUsedInViewPair != null) {
-                mNumSats.setText(mRes.getString(R.string.gps_num_sats_value, numSatsUsedInViewPair.first, numSatsUsedInViewPair.second));
+        public void onChanged(@Nullable final SatelliteMetadata satelliteMetadata) {
+            if (satelliteMetadata != null) {
+                mNumSats.setText(mRes.getString(R.string.gps_num_sats_value,
+                        satelliteMetadata.getNumSatsUsed(),
+                        satelliteMetadata.getNumSatsInView(),
+                        satelliteMetadata.getNumSatsTotal()));
             }
         }
-    };
-
-    private final Observer<Pair<Integer, Integer>> mNumSignalsObserver = numSignalsUsedInViewPair -> {
-        // TODO - add number of signals used and in view to UI
     };
 
     @Override
@@ -234,8 +233,7 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
         GpsTestActivity.getInstance().addListener(this);
 
         mViewModel = ViewModelProviders.of(getActivity()).get(DeviceInfoViewModel.class);
-        mViewModel.getNumSatsUsedInViewPair().observe(getActivity(), mNumSatsObserver);
-        mViewModel.getNumSignalsUsedInViewPair().observe(getActivity(), mNumSignalsObserver);
+        mViewModel.getSatelliteMetadata().observe(getActivity(), mSatelliteMetadataObserver);
 
         return v;
     }

--- a/GPSTest/src/main/java/com/android/gpstest/model/ConstellationFamily.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/model/ConstellationFamily.kt
@@ -17,15 +17,9 @@ package com.android.gpstest.model
 
 /**
  * A container class that holds a group of [satellites] from multiple constellations (e.g., GNSS,
- * SBAS). [satellites] are stored as a map, and the key to the map is the combination of
- * constellation and ID created using SatelliteUtils.createGnssSatelliteKey().
- * Summary statistics on the constellation family such as the number of signals in view
- * ([numSignalsInView]), number of signals used in the fix ([numSignalsUsed], and the number
- * of satellites used in the fix ([numSatsUsed]) (the number of satellites in view is simply the size
- * of [satellites]).
+ * SBAS) and [satelliteMetadata]. [satellites] are stored as a map, and the key to the map is the
+ * combination of constellation and ID created using SatelliteUtils.createGnssSatelliteKey().
  */
 data class ConstellationFamily(
         val satellites: Map<String, Satellite>,
-        val numSignalsInView: Int,
-        val numSignalsUsed: Int,
-        val numSatsUsed: Int)
+        val satelliteMetadata: SatelliteMetadata)

--- a/GPSTest/src/main/java/com/android/gpstest/model/SatelliteMetadata.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/model/SatelliteMetadata.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Sean J. Barbeau
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.gpstest.model
+
+/**
+ * A container class that holds metadata and statistics information about a group of satellites.
+ * Summary statistics on the constellation family such as the number of signals in view
+ * ([numSignalsInView]), number of signals used in the fix ([numSignalsUsed], and the number
+ * of satellites used in the fix ([numSatsUsed]), and the number of satellites in view ([numSatsInView])
+ */
+data class SatelliteMetadata(
+        val numSignalsInView: Int,
+        val numSignalsUsed: Int,
+        val numSignalsTotal: Int,
+        val numSatsInView: Int,
+        val numSatsUsed: Int,
+        val numSatsTotal: Int)

--- a/GPSTest/src/main/res/values/do_not_translate.xml
+++ b/GPSTest/src/main/res/values/do_not_translate.xml
@@ -45,7 +45,7 @@
     <string name="gps_speed_acc_value_miles_hour">%1$.1f mph</string>
     <string name="gps_bearing_value">%1$.1f\u00B0</string>
     <string name="gps_bearing_acc_value">%1$.1f\u00B0</string>
-    <string name="gps_num_sats_value">%1$d/%2$d</string>
+    <string name="gps_num_sats_value">%1$d/%2$d/%3$d</string>
     <string name="pdop_value">%1$.1f</string>
     <string name="hvdop_value">%1$.1f/%2$.1f</string>
     <string name="gps_elevation_column_value">%1$.1f\u00B0</string>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -335,7 +335,7 @@
         <b>B. Acc</b>
         - Estimated bearing accuracy of this location at 68% confidence, in degrees. For example, if Bearing is 60, and Bearing Acc is 10, then there is a 68% probability of the true bearing being between 50 and 70 degrees.\n&#8226;\u0020
         <b># Sats</b>
-        - # satellites used in fix / # satellites in view. On dual-frequency devices, a satellite is shown as used if at least one frequency from that satellite is in use.\n&#8226;\u0020
+        - # satellites used in fix / # satellites in view (with valid signal strength values) / # satellites known to device. On dual-frequency devices, a satellite is shown as used if at least one frequency from that satellite is in use, a satellite is shown as in view if at least one signal has a valid signal strength value, and is shown as known to device if there is information about at least one signal from the satellite.\n&#8226;\u0020
         <b>PDOP</b>
         - Position (3D) dilution of precision (requires NMEA support)\n&#8226;\u0020
         <b>H/V DOP</b>


### PR DESCRIPTION
TODO:
- [x] Wrap satellite/signal counts in SatelliteMetadata object
- [x] Update UI to new "X/Y/Z" format, where X is number of sats used, Y is number of sats in view (with valid C/N0 values), and Z is total number of satellites
- [x] Update tests to new format.
- [x] Add more tests that check for `NO_DATA` C/N0 values (not in view), total satellite and signal counts