### PR TITLE
Fix #369 - Highlight wrong GNSS times on Status

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -159,6 +159,10 @@ Then tap on "Send feedback", and GPSTest it will capture success/failure for all
 
 No.  See our [Privacy Policy](https://github.com/barbeau/gpstest/wiki/Privacy-Policy) for more details.
 
+## Why is my GPS time wrong?
+
+As of April 6, 2019, some older devices have been impacted by the [GPS Week Number Rollover](https://www.cisa.gov/gps-week-number-roll-over), which can result in unpredictable behavior. Typically, the time computed by GPS will be wrong. You will need to contact your device manufacturer or cellular carrier to determine if you device can be updated to fix this issue. For example, here is [Verizon's GPS Week Rollover help page](https://www.verizonwireless.com/legal/notices/global-positioning-system/).
+
 ## I'm getting a weird value for Time-to-First-Fix.  What's up?
 
 On Android 4.1 and below, your system clock must be accurate to calculate an accurate Time-To-First-Fix (TTFF) value

--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -20,6 +20,7 @@ package com.android.gpstest;
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.location.GnssMeasurementsEvent;
@@ -96,6 +97,10 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
             mSpeedView, mSpeedAccuracyView, mBearingView, mBearingAccuracyView, mNumSats,
             mPdopLabelView, mPdopView, mHvdopLabelView, mHvdopView, mGnssNotAvailableView,
             mSbasNotAvailableView;
+
+    private int mDefaultTextColor;
+
+    private final int mErrorTextColor = Color.RED;
 
     private CardView mLocationCard;
 
@@ -272,6 +277,8 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
         if (mFixTime == 0 || (GpsTestActivity.getInstance() != null && !GpsTestActivity.getInstance().mStarted)) {
             mFixTimeView.setText("");
         } else {
+            // TODO - add check for invalid time and UI explanation for red color, change back to default if valid
+            mFixTimeView.setTextColor(mErrorTextColor);
             mFixTimeView.setText(mDateFormat.format(mFixTime));
         }
     }
@@ -343,6 +350,9 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
         setStarted(gta.mStarted);
 
         setupUnitPreferences();
+
+        // Get default text color
+        mDefaultTextColor = mFixTimeView.getTextColors().getDefaultColor();
     }
 
     @Override

--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -46,6 +46,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AlertDialog;
 import androidx.cardview.widget.CardView;
+import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProviders;
@@ -753,13 +754,20 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
     }
 
     private void showTimeErrorDialog(long time) {
-        SimpleDateFormat format = new SimpleDateFormat(
-                DateFormat.is24HourFormat(Application.get().getApplicationContext())
-                        ? "EEE, MMM d yyyy HH:mm:ss z" : "EEE, d MMM yyyy hh:mm:ss z");
+        java.text.DateFormat format = SimpleDateFormat.getDateTimeInstance(java.text.DateFormat.LONG, java.text.DateFormat.LONG);
+
+        TextView textView = (TextView) getLayoutInflater().inflate(R.layout.error_text_dialog, null);
+        textView.setText(getString(R.string.error_time_message, format.format(time), DateTimeUtils.Companion.getNUM_DAYS_TIME_VALID()));
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(R.string.error_time_title);
-        builder.setMessage(getString(R.string.error_time_message, format.format(time), DateTimeUtils.Companion.getNUM_DAYS_TIME_VALID()));
+        builder.setView(textView);
+        Drawable drawable = getResources().getDrawable(android.R.drawable.ic_dialog_alert);
+        DrawableCompat.setTint(drawable, getResources().getColor(R.color.colorPrimary));
+        builder.setIcon(drawable);
+        builder.setNeutralButton(R.string.main_help_close,
+                (dialog, which) -> dialog.dismiss()
+        );
         AlertDialog dialog = builder.create();
         dialog.setOwnerActivity(getActivity());
         dialog.show();

--- a/GPSTest/src/main/java/com/android/gpstest/util/DateTimeUtils.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/util/DateTimeUtils.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Sean J. Barbeau
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.gpstest.util
+
+import android.os.Build
+import androidx.annotation.VisibleForTesting
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+/**
+ * Utilities for comparing two locations to measure error
+ */
+class DateTimeUtils {
+    companion object {
+        /**
+         * Returns true if the provided UTC time of the fix, in milliseconds since January 1, 1970,
+         * is valid, and false if it is not
+         */
+        fun isTimeValid(time: Long): Boolean {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                // If the GPS time is less than one day off system clock time, consider it valid
+                Duration.between(Instant.ofEpochMilli(time), Instant.now()).toHours() < 24
+            } else {
+                isTimeValidLegacy(time)
+            }
+        }
+
+        @VisibleForTesting
+        fun isTimeValidLegacy(time: Long): Boolean {
+            return TimeUnit.MILLISECONDS.toHours(Math.abs(System.currentTimeMillis() - time)) < 24
+        }
+    }
+}

--- a/GPSTest/src/main/java/com/android/gpstest/util/DateTimeUtils.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/util/DateTimeUtils.kt
@@ -26,23 +26,25 @@ import java.util.concurrent.TimeUnit
  * Utilities for comparing two locations to measure error
  */
 class DateTimeUtils {
+
     companion object {
+        val NUM_DAYS_TIME_VALID = 5
         /**
          * Returns true if the provided UTC time of the fix, in milliseconds since January 1, 1970,
          * is valid, and false if it is not
          */
         fun isTimeValid(time: Long): Boolean {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                // If the GPS time is less than one day off system clock time, consider it valid
-                Duration.between(Instant.ofEpochMilli(time), Instant.now()).toHours() < 24
+                // If the GPS time is less than five days different than system clock time, consider it valid
+                Duration.between(Instant.ofEpochMilli(time), Instant.now()).toDays() < NUM_DAYS_TIME_VALID
             } else {
                 isTimeValidLegacy(time)
             }
         }
 
         @VisibleForTesting
-        fun isTimeValidLegacy(time: Long): Boolean {
-            return TimeUnit.MILLISECONDS.toHours(Math.abs(System.currentTimeMillis() - time)) < 24
+        internal fun isTimeValidLegacy(time: Long): Boolean {
+            return TimeUnit.MILLISECONDS.toDays(Math.abs(System.currentTimeMillis() - time)) < NUM_DAYS_TIME_VALID
         }
     }
 }

--- a/GPSTest/src/main/res/drawable/error_text_background.xml
+++ b/GPSTest/src/main/res/drawable/error_text_background.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Outside border -->
+    <item android:id="@+id/error_background_border">
+        <shape>
+            <corners android:radius="9dp" />
+            <padding
+                android:top="3dp"
+                android:left="3dp"
+                android:bottom="3dp"
+                android:right="3dp" />
+            <solid android:color="@color/red" />
+        </shape>
+    </item>
+    <!-- Inside fill -->
+    <item android:id="@+id/error_background_fill">
+        <shape>
+            <corners android:radius="6dp" />
+            <solid android:color="@color/red" />
+        </shape>
+    </item>
+</layer-list>

--- a/GPSTest/src/main/res/layout/error_text_dialog.xml
+++ b/GPSTest/src/main/res/layout/error_text_dialog.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="?android:attr/textAppearance"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="14dp"
+    android:paddingBottom="6dp"
+    android:paddingLeft="24dp"
+    android:paddingRight="10dp"
+    android:textSize="16sp"
+    android:autoLink="all"
+    android:linksClickable="true"></TextView>

--- a/GPSTest/src/main/res/layout/gps_status.xml
+++ b/GPSTest/src/main/res/layout/gps_status.xml
@@ -72,6 +72,11 @@
                         <TextView
                             android:id="@+id/fix_time"
                             style="@style/info_value" />
+
+                        <TextView
+                            android:id="@+id/fix_time_error"
+                            style="@style/info_value_error"
+                            android:visibility="gone" />
                     </TableRow>
 
                     <TableRow>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -113,6 +113,8 @@
     <string name="gnss_not_available">Global Navigation Satellite System (GNSS) satellites not available</string>
     <string name="sbas_not_available">Satellite-based Augmentation System (SBAS) satellites not available</string>
     <string name="menu_option_sort_by">Sort by</string>
+    <string name="error_time_title">Your GNSS time is wrong</string>
+    <string name="error_time_message">The device GNSS time of:\n\n%1$s\n\nis more than %2$d days different from your system clock. This can be caused by the GPS week rollover issue. See  for more details.</string>
 
     <!-- Map view -->
     <string name="ground_truth_latitude">Your latitude</string>

--- a/GPSTest/src/main/res/values/strings.xml
+++ b/GPSTest/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="sbas_not_available">Satellite-based Augmentation System (SBAS) satellites not available</string>
     <string name="menu_option_sort_by">Sort by</string>
     <string name="error_time_title">Your GNSS time is wrong</string>
-    <string name="error_time_message">The device GNSS time of:\n\n%1$s\n\nis more than %2$d days different from your system clock. This can be caused by the GPS week rollover issue. See  for more details.</string>
+    <string name="error_time_message">The device GNSS time of:\n\n%1$s\n\n…is more than %2$d days different from your system clock. This can be caused by the GPS week rollover issue - ask your device manufacturer for details. See http://bit.ly/gps-week-rollover for more info.</string>
 
     <!-- Map view -->
     <string name="ground_truth_latitude">Your latitude</string>

--- a/GPSTest/src/main/res/values/styles.xml
+++ b/GPSTest/src/main/res/values/styles.xml
@@ -71,6 +71,19 @@
         <item name="android:textStyle">normal</item>
     </style>
 
+    <style name="info_value_error">
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:textSize">@dimen/status_text_size</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:paddingTop">3dp</item>
+        <item name="android:paddingBottom">3dp</item>
+        <item name="android:paddingLeft">6dp</item>
+        <item name="android:paddingRight">6dp</item>
+        <item name="android:background">@drawable/error_text_background</item>
+    </style>
+
     <!-- GNSS Sky view -->
     <style name="sky_legend_label">
         <item name="android:layout_height">wrap_content</item>

--- a/GPSTest/src/test/java/com/android/gpstest/util/DateTimeUtilsTest.kt
+++ b/GPSTest/src/test/java/com/android/gpstest/util/DateTimeUtilsTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Sean J. Barbeau
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.gpstest.util
+
+import junit.framework.Assert.assertFalse
+import junit.framework.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+class DateTimeUtilsTest {
+
+    @Test
+    fun isTimeValid() {
+        // Valid times within 24 hours of now
+        assertTrue(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli()))
+        assertTrue(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() + TimeUnit.HOURS.toMillis(23)))
+        assertTrue(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() - TimeUnit.HOURS.toMillis(23)))
+
+        // Invalid times more than 24 hours from now (past or future)
+        assertFalse(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() + TimeUnit.HOURS.toMillis(25)))
+        assertFalse(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() - TimeUnit.HOURS.toMillis(25)))
+    }
+
+    @Test
+    fun isTimeValidLegacy() {
+        // Valid times within 24 hours of now
+        assertTrue(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli()))
+        assertTrue(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() + TimeUnit.HOURS.toMillis(23)))
+        assertTrue(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() - TimeUnit.HOURS.toMillis(23)))
+
+        // Invalid times more than 24 hours from now (past or future)
+        assertFalse(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() + TimeUnit.HOURS.toMillis(25)))
+        assertFalse(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() - TimeUnit.HOURS.toMillis(25)))
+    }
+}

--- a/GPSTest/src/test/java/com/android/gpstest/util/DateTimeUtilsTest.kt
+++ b/GPSTest/src/test/java/com/android/gpstest/util/DateTimeUtilsTest.kt
@@ -25,25 +25,25 @@ class DateTimeUtilsTest {
 
     @Test
     fun isTimeValid() {
-        // Valid times within 24 hours of now
+        // Valid times within 5 days of now
         assertTrue(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli()))
-        assertTrue(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() + TimeUnit.HOURS.toMillis(23)))
-        assertTrue(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() - TimeUnit.HOURS.toMillis(23)))
+        assertTrue(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() + TimeUnit.DAYS.toMillis(4)))
+        assertTrue(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() - TimeUnit.DAYS.toMillis(4)))
 
-        // Invalid times more than 24 hours from now (past or future)
-        assertFalse(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() + TimeUnit.HOURS.toMillis(25)))
-        assertFalse(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() - TimeUnit.HOURS.toMillis(25)))
+        // Invalid times more than 5 days  from now (past or future)
+        assertFalse(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() + TimeUnit.DAYS.toMillis(6)))
+        assertFalse(DateTimeUtils.isTimeValid(Instant.now().toEpochMilli() - TimeUnit.DAYS.toMillis(6)))
     }
 
     @Test
     fun isTimeValidLegacy() {
-        // Valid times within 24 hours of now
+        // Valid times within 5 days of now
         assertTrue(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli()))
-        assertTrue(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() + TimeUnit.HOURS.toMillis(23)))
-        assertTrue(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() - TimeUnit.HOURS.toMillis(23)))
+        assertTrue(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() + TimeUnit.DAYS.toMillis(4)))
+        assertTrue(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() - TimeUnit.DAYS.toMillis(4)))
 
-        // Invalid times more than 24 hours from now (past or future)
-        assertFalse(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() + TimeUnit.HOURS.toMillis(25)))
-        assertFalse(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() - TimeUnit.HOURS.toMillis(25)))
+        // Invalid times more than 5 days from now (past or future)
+        assertFalse(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() + TimeUnit.DAYS.toMillis(6)))
+        assertFalse(DateTimeUtils.isTimeValidLegacy(Instant.now().toEpochMilli() - TimeUnit.DAYS.toMillis(6)))
     }
 }

--- a/GPSTest/src/test/java/com/android/gpstest/util/MathUtilTest.java
+++ b/GPSTest/src/test/java/com/android/gpstest/util/MathUtilTest.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.android.gpstest;
-
-import com.android.gpstest.util.MathUtils;
+package com.android.gpstest.util;
 
 import org.junit.Test;
 

--- a/GPSTest/src/test/java/com/android/gpstest/util/NmeaUtilsTest.java
+++ b/GPSTest/src/test/java/com/android/gpstest/util/NmeaUtilsTest.java
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.android.gpstest;
+package com.android.gpstest.util;
 
 import com.android.gpstest.model.DilutionOfPrecision;
-import com.android.gpstest.util.NmeaUtils;
 
 import org.junit.Test;
 

--- a/GPSTest/src/test/java/com/android/gpstest/util/UIUtilsTest.java
+++ b/GPSTest/src/test/java/com/android/gpstest/util/UIUtilsTest.java
@@ -1,6 +1,4 @@
-package com.android.gpstest;
-
-import com.android.gpstest.util.UIUtils;
+package com.android.gpstest.util;
 
 import org.junit.Test;
 


### PR DESCRIPTION
This shows GNSS times that are more than 5 days different than the system clock with a red background, and if you tap on it it shows an error dialog with a link to more info on GPS week rollover.

![image](https://user-images.githubusercontent.com/928045/74961898-e0f0a800-53dc-11ea-9223-e4b56110bd21.png)

TODO:
- [x] Update dialog with shortened link to documentation