### PR TITLE
feat: Add date to Status view for wide screens

### DIFF
--- a/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsStatusFragment.java
@@ -88,9 +88,13 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
     private static final String EMPTY_LAT_LONG = "             ";
 
     @SuppressLint("SimpleDateFormat") // See #117
-    SimpleDateFormat mDateFormat = new SimpleDateFormat(
+    SimpleDateFormat mTimeFormat = new SimpleDateFormat(
             DateFormat.is24HourFormat(Application.get().getApplicationContext())
                     ? "HH:mm:ss" : "hh:mm:ss a");
+
+    SimpleDateFormat mTimeAndDateFormat = new SimpleDateFormat(
+            DateFormat.is24HourFormat(Application.get().getApplicationContext())
+                    ? "HH:mm:ss" : "hh:mm:ss a MMM d, yyyy z");
 
     private Resources mRes;
 
@@ -285,14 +289,22 @@ public class GpsStatusFragment extends Fragment implements GpsTestListener {
             if (DateTimeUtils.Companion.isTimeValid(mFixTime)) {
                 mFixTimeErrorView.setVisibility(View.GONE);
                 mFixTimeView.setVisibility(View.VISIBLE);
-                mFixTimeView.setText(mDateFormat.format(mFixTime));
+                mFixTimeView.setText(formatFixTimeDate(mFixTime));
             } else {
                 // Error in fix time
                 mFixTimeErrorView.setVisibility(View.VISIBLE);
                 mFixTimeView.setVisibility(View.GONE);
-                mFixTimeErrorView.setText(mDateFormat.format(mFixTime));
+                mFixTimeErrorView.setText(formatFixTimeDate(mFixTime));
             }
         }
+    }
+
+    /**
+     * Returns a formatted version of the provided fixTime based on the width of the current display
+     * @return a formatted version of the provided fixTime based on the width of the current display
+     */
+    private String formatFixTimeDate(long fixTime) {
+        return UIUtils.isWideEnoughForDate(getContext()) ? mTimeAndDateFormat.format(fixTime) : mTimeFormat.format(fixTime);
     }
 
     /**

--- a/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
@@ -96,6 +96,19 @@ public class UIUtils {
     }
 
     /**
+     * Returns true if the current display is wide enough to show the GPS date on the Status screen,
+     * false if the current display is too narrow to fit the GPS date
+     * @param context
+     * @return true if the current display is wide enough to show the GPS date on the Status screen,
+     *      false if the current display is too narrow to fit the GPS date
+     */
+    public static boolean isWideEnoughForDate(Context context) {
+        // 450dp is a little larger than the width of a Samsung Galaxy S8+
+        final int WIDTH_THRESHOLD = dpToPixels(context, 450);
+        return context.getResources().getDisplayMetrics().widthPixels > WIDTH_THRESHOLD;
+    }
+
+    /**
      * Returns true if the activity is still active and dialogs can be managed (i.e., displayed
      * or dismissed), or false if it is not
      *


### PR DESCRIPTION
This adds date to the Status view when the screen width is more than 450dp (including when the screen is rotated to landscape).

Closes #409.

Here are example screenshots from a Samsung Galaxy S8+ - the date doesn't appear when in portrait but appears in landscape:

![image](https://user-images.githubusercontent.com/928045/84839235-91c52780-b00a-11ea-9685-c8f779a65409.png)

![image](https://user-images.githubusercontent.com/928045/84839241-97bb0880-b00a-11ea-98ea-c67a867ea5a9.png)

TODO:
- [x] Test on wider screens to see if threshold is about right