### PR TITLE
chore: Bump compile/targetSdkVerion, build tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ stages:
 
 env:
   global:
-    - BUILD_TOOLS=28.0.3
-    - COMPILE_SDK_VERSION=28
+    - BUILD_TOOLS=29.0.3
+    - COMPILE_SDK_VERSION=30
     - ABI=x86_64
     - ADB_INSTALL_TIMEOUT=8
     - ANDROID_HOME=${HOME}/android-sdk

--- a/GPSTest/build.gradle
+++ b/GPSTest/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 30
+    buildToolsVersion '29.0.3'
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 28
+        targetSdkVersion 29
         // versionCode scheme - first two digits are minSdkVersion, last three digits are build number
         versionCode 18071
         versionName "3.7.4"

--- a/GPSTest/src/androidTest/java/com/android/gpstest/IOUtilsTest.kt
+++ b/GPSTest/src/androidTest/java/com/android/gpstest/IOUtilsTest.kt
@@ -124,22 +124,22 @@ class IOUtilsTest {
     @Test
     fun testCreateShowRadarIntent() {
         val resultNoAltitude = IOUtils.createShowRadarIntent(24.5253, 87.23434, null)
-        assertEquals(24.5253, resultNoAltitude.extras["latitude"])
-        assertEquals(87.23434, resultNoAltitude.extras["longitude"])
+        assertEquals(24.5253, resultNoAltitude?.extras?.get("latitude"))
+        assertEquals(87.23434, resultNoAltitude?.extras?.get("longitude"))
         assertFalse(resultNoAltitude.hasExtra("altitude"))
 
         val resultWithAltitude = IOUtils.createShowRadarIntent(24.5253, 87.23434, 15.5)
-        assertEquals(24.5253, resultWithAltitude.extras["latitude"])
-        assertEquals(87.23434, resultWithAltitude.extras["longitude"])
-        assertEquals(15.5, resultWithAltitude.extras["altitude"])
+        assertEquals(24.5253, resultWithAltitude.extras?.get("latitude"))
+        assertEquals(87.23434, resultWithAltitude.extras?.get("longitude"))
+        assertEquals(15.5, resultWithAltitude.extras?.get("altitude"))
 
         val locationNoAltitude = Location("TestNoAltitude")
         locationNoAltitude.latitude = -20.8373
         locationNoAltitude.longitude = -120.8273
 
         val resultFromLocationNoAltitude = IOUtils.createShowRadarIntent(locationNoAltitude)
-        assertEquals(-20.8373, resultFromLocationNoAltitude.extras["latitude"])
-        assertEquals(-120.8273, resultFromLocationNoAltitude.extras["longitude"])
+        assertEquals(-20.8373, resultFromLocationNoAltitude?.extras?.get("latitude"))
+        assertEquals(-120.8273, resultFromLocationNoAltitude?.extras?.get("longitude"))
         assertFalse(resultNoAltitude.hasExtra("altitude"))
 
         val locationWithAltitude = Location("TestWithAltitude")
@@ -148,9 +148,9 @@ class IOUtilsTest {
         locationWithAltitude.altitude = -13.5
 
         val resultFromLocationWithAltitude = IOUtils.createShowRadarIntent(locationWithAltitude)
-        assertEquals(-26.8373, resultFromLocationWithAltitude.extras["latitude"])
-        assertEquals(-126.8273, resultFromLocationWithAltitude.extras["longitude"])
-        assertEquals(-13.5, resultFromLocationWithAltitude.extras["altitude"])
+        assertEquals(-26.8373, resultFromLocationWithAltitude.extras?.get("latitude"))
+        assertEquals(-126.8273, resultFromLocationWithAltitude.extras?.get("longitude"))
+        assertEquals(-13.5, resultFromLocationWithAltitude.extras?.get("altitude"))
 
     }
 

--- a/GPSTest/src/main/java/com/android/gpstest/util/SatelliteUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/SatelliteUtils.java
@@ -47,8 +47,6 @@ public class SatelliteUtils {
 
     private static final String TAG = "SatelliteUtils";
 
-    private static final int CONSTELLATION_IRNSS_TEMP = 7;
-
     /**
      * Returns the Global Navigation Satellite System (GNSS) for a satellite given the PRN.  For
      * Android 6.0.1 (API Level 23) and lower.  Android 7.0 and higher should use getGnssConstellationType()
@@ -116,11 +114,7 @@ public class SatelliteUtils {
                 return QZSS;
             case GnssStatus.CONSTELLATION_GALILEO:
                 return GALILEO;
-            case CONSTELLATION_IRNSS_TEMP:
-                // FIX ME - We can't use the GnssStatus.CONSTELLATION_IRNSS Android SDK constant in
-                // this switch statement until this Android bug is fixed - https://issuetracker.google.com/issues/134611316
-                // For now, we define CONSTELLATION_IRNSS_TEMP to be the same value of 7 so we can
-                // still support IRNSS.
+            case GnssStatus.CONSTELLATION_IRNSS:
                 return IRNSS;
             case GnssStatus.CONSTELLATION_SBAS:
                 return SBAS;


### PR DESCRIPTION
Also changes to canonical GnssStatus.CONSTELLATION_IRNSS, and therefore closes #340.

Closes #340
Closes #420