### PR TITLE
feat: Add indicators for acquiring/acquired GNSS fix

### DIFF
--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -950,6 +950,7 @@ public class GpsTestActivity extends AppCompatActivity
         if (mStarted) {
             mLocationManager.removeUpdates(this);
             mStarted = false;
+            haveFix = false;
 
             // Reset the options menu to trigger updates to action bar menu items
             invalidateOptionsMenu();

--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -1012,20 +1012,7 @@ public class GpsTestActivity extends AppCompatActivity
             public void onSatelliteStatusChanged(GnssStatus status) {
                 mGnssStatus = status;
 
-                if (mLastLocation != null && progressBar != null) {
-                    if ((SystemClock.elapsedRealtimeNanos() - mLastLocation.getElapsedRealtimeNanos()) >
-                            TimeUnit.MILLISECONDS.toNanos(minTime * 2)) {
-                        // We lost the GNSS fix for two requested update intervals - show the progress bar while we try to obtain another one
-                        UIUtils.showViewWithAnimation(progressBar, UIUtils.ANIMATION_DURATION_SHORT_MS);
-
-                        // TODO - hide lock icon
-                    } else {
-                        // We have a GNSS fix - hide the progress bar
-                        UIUtils.hideViewWithAnimation(progressBar, UIUtils.ANIMATION_DURATION_SHORT_MS);
-
-                        // TODO - show lock icon
-                    }
-                }
+                checkHaveFix();
 
                 for (GpsTestListener listener : mGpsTestListeners) {
                     listener.onSatelliteStatusChanged(mGnssStatus);
@@ -1033,6 +1020,23 @@ public class GpsTestActivity extends AppCompatActivity
             }
         };
         mLocationManager.registerGnssStatusCallback(mGnssStatusListener);
+    }
+
+    private void checkHaveFix() {
+        if (mLastLocation != null && progressBar != null) {
+            if ((SystemClock.elapsedRealtimeNanos() - mLastLocation.getElapsedRealtimeNanos()) >
+                    TimeUnit.MILLISECONDS.toNanos(minTime * 2)) {
+                // We lost the GNSS fix for two requested update intervals - show the progress bar while we try to obtain another one
+                UIUtils.showViewWithAnimation(progressBar, UIUtils.ANIMATION_DURATION_SHORT_MS);
+
+                // TODO - hide lock icon
+            } else {
+                // We have a GNSS fix - hide the progress bar
+                UIUtils.hideViewWithAnimation(progressBar, UIUtils.ANIMATION_DURATION_SHORT_MS);
+
+                // TODO - show lock icon
+            }
+        }
     }
 
     @SuppressLint("MissingPermission")
@@ -1100,10 +1104,14 @@ public class GpsTestActivity extends AppCompatActivity
                     case GpsStatus.GPS_EVENT_STOPPED:
                         break;
                     case GpsStatus.GPS_EVENT_FIRST_FIX:
+                        if (progressBar != null) {
+                            // We got an initial fix, hide the progress bar
+                            UIUtils.hideViewWithAnimation(progressBar, UIUtils.ANIMATION_DURATION_SHORT_MS);
+                            // TODO - show lock icon
+                        }
                         break;
                     case GpsStatus.GPS_EVENT_SATELLITE_STATUS:
-                        // Stop progress bar after the first status information is obtained
-                        setSupportProgressBarIndeterminateVisibility(Boolean.FALSE);
+                        checkHaveFix();
                         break;
                 }
 

--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -1130,11 +1130,8 @@ public class GpsTestActivity extends AppCompatActivity
                     case GpsStatus.GPS_EVENT_STOPPED:
                         break;
                     case GpsStatus.GPS_EVENT_FIRST_FIX:
-                        if (progressBar != null) {
-                            // We got an initial fix, hide the progress bar
-                            UIUtils.hideViewWithAnimation(progressBar, UIUtils.ANIMATION_DURATION_SHORT_MS);
-                            // TODO - show lock icon
-                        }
+                        haveFix = true;
+                        showHaveFix();
                         break;
                     case GpsStatus.GPS_EVENT_SATELLITE_STATUS:
                         checkHaveFix();

--- a/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
@@ -15,6 +15,8 @@
  */
 package com.android.gpstest.util;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.ActivityNotFoundException;
@@ -74,6 +76,10 @@ public class UIUtils {
     public static final String COORDINATE_LONGITUDE = "lon";
 
     public static int PICKFILE_REQUEST_CODE = 101;
+
+    public static final int ANIMATION_DURATION_SHORT_MS = 200;
+    public static final int ANIMATION_DURATION_MEDIUM_MS = 400;
+    public static final int ANIMATION_DURATION_LONG_MS = 500;
 
     /**
      * Formats a view so it is ignored for accessible access
@@ -806,5 +812,62 @@ public class UIUtils {
         for (ClickableSpan cs : spans) {
             text.removeSpan(cs);
         }
+    }
+
+    /**
+     * Shows a view using animation
+     *
+     * @param v                 View to show
+     * @param animationDuration duration of animation
+     */
+    public static void showViewWithAnimation(final View v, int animationDuration) {
+        if (v.getVisibility() == View.VISIBLE && v.getAlpha() == 1) {
+            // View is already visible and not transparent, return without doing anything
+            return;
+        }
+
+        v.clearAnimation();
+        v.animate().cancel();
+
+        if (v.getVisibility() != View.VISIBLE) {
+            // Set the content view to 0% opacity but visible, so that it is visible
+            // (but fully transparent) during the animation.
+            v.setAlpha(0f);
+            v.setVisibility(View.VISIBLE);
+        }
+
+        // Animate the content view to 100% opacity, and clear any animation listener set on the view.
+        v.animate()
+                .alpha(1f)
+                .setDuration(animationDuration)
+                .setListener(null);
+    }
+
+    /**
+     * Hides a view using animation
+     *
+     * @param v                 View to hide
+     * @param animationDuration duration of animation
+     */
+    public static void hideViewWithAnimation(final View v, int animationDuration) {
+        if (v.getVisibility() == View.GONE) {
+            // View is already gone, return without doing anything
+            return;
+        }
+
+        v.clearAnimation();
+        v.animate().cancel();
+
+        // Animate the view to 0% opacity. After the animation ends, set its visibility to GONE as
+        // an optimization step (it won't participate in layout passes, etc.)
+        v.animate()
+                .alpha(0f)
+                .setDuration(animationDuration)
+                .setListener(new AnimatorListenerAdapter() {
+                    @Override
+                    public void onAnimationEnd(Animator animation) {
+                        v.setVisibility(View.GONE);
+                    }
+                });
     }
 }

--- a/GPSTest/src/main/res/drawable/ic_baseline_lock_24.xml
+++ b/GPSTest/src/main/res/drawable/ic_baseline_lock_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="15dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="15dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+</vector>

--- a/GPSTest/src/main/res/layout/content_main.xml
+++ b/GPSTest/src/main/res/layout/content_main.xml
@@ -76,6 +76,16 @@
                 android:layout_centerInParent="true"
                 android:layout_marginTop="-7dp"
                 android:indeterminate="true"/>
+            <ImageView
+                android:id="@+id/lock"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentStart="true"
+                android:layout_marginStart="15dp"
+                android:layout_marginTop="15dp"
+                app:srcCompat="@drawable/ic_baseline_lock_24"
+                android:visibility="gone"/>
         </RelativeLayout>
 
         <!-- Bottom sliding panel -->

--- a/GPSTest/src/main/res/layout/content_main.xml
+++ b/GPSTest/src/main/res/layout/content_main.xml
@@ -66,6 +66,16 @@
                 android:layout_marginEnd="@dimen/map_motion_outer_margin"
                 android:layout_marginTop="@dimen/map_motion_outer_margin"
                 android:layout_marginBottom="@dimen/map_motion_outer_margin" />
+            <!-- Progress bar for when GNSS is attempting fix -->
+            <ProgressBar
+                android:id="@+id/progress_horizontal"
+                style="@style/Base.Widget.AppCompat.ProgressBar.Horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_centerInParent="true"
+                android:layout_marginTop="-7dp"
+                android:indeterminate="true"/>
         </RelativeLayout>
 
         <!-- Bottom sliding panel -->


### PR DESCRIPTION
This PR adds a progress bar that is shown when the GNSS is attempting to acquire a fix (including after it's acquired but then lost a fix), and disappears when a lock is acquired. A lock icon that has the inverse behavior will also be shown.

TODO:
- [x] Add legacy GPSStatus impl
- [x] Add lock icon
- [x] Switch lock icon visible/hidden, opposite of progress bar
- [x] Hide and show progress bar, locked indicator when starting and stopping GNSS from switch

Closes #417