### PR TITLE
chore: Remove unused parameters in Kotlin code

### DIFF
--- a/GPSTest/src/main/java/com/android/gpstest/dialog/ShareDialogFragment.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/dialog/ShareDialogFragment.kt
@@ -45,7 +45,7 @@ class ShareDialogFragment : DialogFragment() {
         val builder = AlertDialog.Builder(activity!!)
                 .setTitle(R.string.share)
                 .setView(view)
-                .setNeutralButton(R.string.main_help_close) { dialog, which -> }
+                .setNeutralButton(R.string.main_help_close) { dialog, _ -> }
         shareCollectionAdapter = ShareCollectionAdapter(this)
         shareCollectionAdapter.setArguments(arguments)
         shareCollectionAdapter.setListener(listener)

--- a/GPSTest/src/main/java/com/android/gpstest/dialog/ShareLocationFragment.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/dialog/ShareLocationFragment.kt
@@ -71,7 +71,7 @@ class ShareLocationFragment : Fragment() {
         // Change the location text when the user toggles the altitude checkbox
 
         // Change the location text when the user toggles the altitude checkbox
-        includeAltitude.setOnCheckedChangeListener { view1: CompoundButton?, isChecked: Boolean ->
+        includeAltitude.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
             var format = "dd"
             if (chipDecimalDegrees.isChecked) {
                 format = "dd"
@@ -84,12 +84,12 @@ class ShareLocationFragment : Fragment() {
             PreferenceUtils.saveBoolean(Application.get().getString(R.string.pref_key_share_include_altitude), isChecked)
         }
 
-        chipDecimalDegrees.setOnCheckedChangeListener { view1: CompoundButton?, isChecked: Boolean ->
+        chipDecimalDegrees.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
             if (isChecked) {
                 locationValue.text = IOUtils.createLocationShare(location, includeAltitude.isChecked)
             }
         }
-        chipDMS.setOnCheckedChangeListener { view1: CompoundButton?, isChecked: Boolean ->
+        chipDMS.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
             if (isChecked) {
                 if (location != null) {
                     locationValue.text = IOUtils.createLocationShare(UIUtils.getDMSFromLocation(Application.get(), location.getLatitude(), UIUtils.COORDINATE_LATITUDE),
@@ -98,7 +98,7 @@ class ShareLocationFragment : Fragment() {
                 }
             }
         }
-        chipDegreesDecimalMin.setOnCheckedChangeListener { view1: CompoundButton?, isChecked: Boolean ->
+        chipDegreesDecimalMin.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
             if (isChecked) {
                 if (location != null) {
                     locationValue.text = IOUtils.createLocationShare(UIUtils.getDDMFromLocation(Application.get(), location.getLatitude(), UIUtils.COORDINATE_LATITUDE),
@@ -108,7 +108,7 @@ class ShareLocationFragment : Fragment() {
             }
         }
 
-        locationCopy.setOnClickListener { v: View? ->
+        locationCopy.setOnClickListener { _: View? ->
             // Copy to clipboard
             if (location != null) {
                 val locationString = locationValue.text.toString()
@@ -116,7 +116,7 @@ class ShareLocationFragment : Fragment() {
                 Toast.makeText(activity, R.string.copied_to_clipboard, Toast.LENGTH_LONG).show()
             }
         }
-        locationGeohack.setOnClickListener { v: View? ->
+        locationGeohack.setOnClickListener { _: View? ->
             // Open the browser to the GeoHack site with lots of coordinate conversions
             if (location != null) {
                 val intent = Intent(Intent.ACTION_VIEW)
@@ -127,7 +127,7 @@ class ShareLocationFragment : Fragment() {
                 activity!!.startActivity(intent)
             }
         }
-        locationLaunchApp.setOnClickListener { v: View? ->
+        locationLaunchApp.setOnClickListener { _: View? ->
             // Open the location in another app
             if (location != null) {
                 val intent = Intent(Intent.ACTION_VIEW)
@@ -137,7 +137,7 @@ class ShareLocationFragment : Fragment() {
                 }
             }
         }
-        locationShare.setOnClickListener { v: View? ->
+        locationShare.setOnClickListener { _: View? ->
             // Send the location as a Geo URI (e.g., in an email) if the user has decimal degrees
             // selected, otherwise send plain text version
             if (location != null) {

--- a/GPSTest/src/main/java/com/android/gpstest/dialog/ShareLogFragment.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/dialog/ShareLogFragment.kt
@@ -83,7 +83,7 @@ class ShareLogFragment : Fragment() {
             }
         }
 
-        logBrowse.setOnClickListener { v: View? ->
+        logBrowse.setOnClickListener { _: View? ->
             // File browse
             val uri = IOUtils.getUriFromFile(activity, files?.get(0))
             val intent = Intent(Intent.ACTION_GET_CONTENT)
@@ -93,7 +93,7 @@ class ShareLogFragment : Fragment() {
             listener.onFileBrowse()
         }
 
-        logShare.setOnClickListener { v: View? ->
+        logShare.setOnClickListener { _: View? ->
             // Send the log file
             if (alternateFileUri == null && files != null) {
                 // Send the log file currently being logged to by the FileLogger

--- a/GPSTest/src/main/java/com/android/gpstest/dialog/UploadDeviceInfoFragment.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/dialog/UploadDeviceInfoFragment.kt
@@ -84,7 +84,7 @@ class UploadDeviceInfoFragment : Fragment() {
             }
         }
 
-        upload.setOnClickListener { v: View? ->
+        upload.setOnClickListener { _: View? ->
             var versionName = ""
             var versionCode = ""
             try {


### PR DESCRIPTION
Remove unused parameters in Kotlin code.. This reduces the unused warnings from the
Kotlin compiler during build. Also,  prevents IllegalArgumentException if parameter was null and
was marked non-null.

  - see https://kotlinlang.org/docs/reference/lambdas.html#underscore-for-unused-variables-since-11

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Acknowledge that you're contributing your code under Apache v2.0 license

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.