### PR TITLE
chore: cleanup various code style warnings..

### DIFF
--- a/GPSTest/src/google/java/com/android/gpstest/GpsMapFragment.java
+++ b/GPSTest/src/google/java/com/android/gpstest/GpsMapFragment.java
@@ -225,7 +225,7 @@ public class GpsMapFragment extends SupportMapFragment
                         .geodesic(true));
                 } else {
                     mErrorLine.setPoints(Arrays.asList(gt, current));
-                };
+                }
             }
             if (mMapController.getMode().equals(MODE_ACCURACY) && mLastLocation != null) {
                 // Draw line between this and last location

--- a/GPSTest/src/main/java/com/android/gpstest/GpsSkyFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsSkyFragment.java
@@ -97,7 +97,7 @@ public class GpsSkyFragment extends Fragment implements GpsTestListener {
             color = getResources().getColor(android.R.color.secondary_text_dark);
             circleUsedInFix.setImageResource(R.drawable.circle_used_in_fix_dark);
             usedCn0Background = R.drawable.cn0_round_corner_background_used_dark;
-            usedCn0IndicatorColor = getResources().getColor(android.R.color.darker_gray);;
+            usedCn0IndicatorColor = getResources().getColor(android.R.color.darker_gray);
         } else {
             // Light theme
             color = getResources().getColor(R.color.body_text_2_light);

--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -1077,7 +1077,7 @@ public class GpsTestActivity extends AppCompatActivity
     @SuppressLint("NewApi")
     private void removeGnssAntennaListener() {
         if (mLocationManager != null && SatelliteUtils.isGnssAntennaInfoSupported(mLocationManager) && gnssAntennaInfoListener != null) {
-            mLocationManager.unregisterAntennaInfoListener(gnssAntennaInfoListener);;
+            mLocationManager.unregisterAntennaInfoListener(gnssAntennaInfoListener);
         }
     }
 

--- a/GPSTest/src/main/java/com/android/gpstest/view/GpsSkyView.java
+++ b/GPSTest/src/main/java/com/android/gpstest/view/GpsSkyView.java
@@ -53,13 +53,13 @@ public class GpsSkyView extends View implements GpsTestListener {
 
     private static int SAT_RADIUS;
 
-    private float mSnrThresholds[];
+    private float[] mSnrThresholds;
 
-    private int mSnrColors[];
+    private int[] mSnrColors;
 
-    private float mCn0Thresholds[];
+    private float[] mCn0Thresholds;
 
-    private int mCn0Colors[];
+    private int[] mCn0Colors;
 
     Context mContext;
 
@@ -73,15 +73,20 @@ public class GpsSkyView extends View implements GpsTestListener {
 
     private boolean mStarted;
 
-    private float mSnrCn0s[], mElevs[], mAzims[];  // Holds either SNR or C/N0 - see #65
+    private float[] mSnrCn0s;  // Holds either SNR or C/N0 - see #65
+    private float[] mElevs;
+    private float[] mAzims;
 
     private float mSnrCn0UsedAvg = 0.0f;
 
     private float mSnrCn0InViewAvg = 0.0f;
 
-    private boolean mHasEphemeris[], mHasAlmanac[], mUsedInFix[];
+    private boolean[] mHasEphemeris;
+    private boolean[] mHasAlmanac;
+    private boolean[] mUsedInFix;
 
-    private int mPrns[], mConstellationType[];
+    private int[] mPrns;
+    private int[] mConstellationType;
 
     private int mSvCount;
 
@@ -595,8 +600,8 @@ public class GpsSkyView extends View implements GpsTestListener {
      */
     public synchronized int getSatelliteColor(float snrCn0) {
         int numSteps;
-        final float thresholds[];
-        final int colors[];
+        final float[] thresholds;
+        final int[] colors;
 
         if (!mUseLegacyGnssApi || mIsSnrBad) {
             // Use C/N0 ranges/colors for both C/N0 and SNR on Android 7.0 and higher (see #76)


### PR DESCRIPTION
Android Studio analyzer caught these. These changes will reduce the warnings in Android Studio.

fyi - As a side note, I do find when working in Java code it is preferable to use "Java style"
array definitions as opposed to "C style".. It helps me to think in the right paradigm..

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Acknowledge that you're contributing your code under Apache v2.0 license

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.