### PR TITLE
chore: Cleanup the code a little bit

### DIFF
--- a/GPSTest/src/google/java/com/android/gpstest/GpsMapFragment.java
+++ b/GPSTest/src/google/java/com/android/gpstest/GpsMapFragment.java
@@ -445,11 +445,11 @@ public class GpsMapFragment extends SupportMapFragment
     private void checkMapPreferences() {
         SharedPreferences settings = Application.getPrefs();
         if (mMap != null && mMapController.getMode().equals(MODE_MAP)) {
-            if (mMap.getMapType() != Integer.valueOf(
+            if (mMap.getMapType() != Integer.parseInt(
                     settings.getString(getString(R.string.pref_key_map_type),
                             String.valueOf(GoogleMap.MAP_TYPE_NORMAL))
             )) {
-                mMap.setMapType(Integer.valueOf(
+                mMap.setMapType(Integer.parseInt(
                         settings.getString(getString(R.string.pref_key_map_type),
                                 String.valueOf(GoogleMap.MAP_TYPE_NORMAL))
                 ));

--- a/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
+++ b/GPSTest/src/main/java/com/android/gpstest/GpsTestActivity.java
@@ -238,7 +238,7 @@ public class GpsTestActivity extends AppCompatActivity
     private GnssAntennaInfo.Listener gnssAntennaInfoListener;
 
     // Listeners for Fragments
-    private List<GpsTestListener> mGpsTestListeners = new ArrayList<GpsTestListener>();
+    private List<GpsTestListener> mGpsTestListeners = new ArrayList<>();
 
     private Location mLastLocation;
 
@@ -619,12 +619,12 @@ public class GpsTestActivity extends AppCompatActivity
         // Apply start state settings from preferences
         SharedPreferences settings = Application.getPrefs();
 
-        double tempMinTime = Double.valueOf(
+        double tempMinTime = Double.parseDouble(
                 settings.getString(getString(R.string.pref_key_gps_min_time),
                         getString(R.string.pref_gps_min_time_default_sec))
         );
         minTime = (long) (tempMinTime * SECONDS_TO_MILLISECONDS);
-        minDistance = Float.valueOf(
+        minDistance = Float.parseFloat(
                 settings.getString(getString(R.string.pref_key_gps_min_distance),
                         getString(R.string.pref_gps_min_distance_default_meters))
         );
@@ -980,10 +980,10 @@ public class GpsTestActivity extends AppCompatActivity
             showProgressBar();
 
             // Show Toast only if the user has set minTime or minDistance to something other than default values
-            if (minTime != (long) (Double.valueOf(getString(R.string.pref_gps_min_time_default_sec))
+            if (minTime != (long) (Double.parseDouble(getString(R.string.pref_gps_min_time_default_sec))
                     * SECONDS_TO_MILLISECONDS) ||
                     minDistance != Float
-                            .valueOf(getString(R.string.pref_gps_min_distance_default_meters))) {
+                            .parseFloat(getString(R.string.pref_gps_min_distance_default_meters))) {
                 Toast.makeText(this, String.format(getString(R.string.gps_set_location_listener),
                         String.valueOf((double) minTime / SECONDS_TO_MILLISECONDS),
                         String.valueOf(minDistance)), Toast.LENGTH_SHORT).show();
@@ -1232,9 +1232,7 @@ public class GpsTestActivity extends AppCompatActivity
                 if (UIUtils.canManageDialog(GpsTestActivity.this) &&
                         (mWriteRawMeasurementToAndroidMonitor || mWriteRawMeasurementsToFile)) {
                     new Handler(Looper.getMainLooper()).postDelayed(
-                            () -> runOnUiThread(() -> {
-                                Toast.makeText(GpsTestActivity.this, statusMessage, Toast.LENGTH_SHORT).show();
-                            }), 3000);
+                            () -> runOnUiThread(() -> Toast.makeText(GpsTestActivity.this, statusMessage, Toast.LENGTH_SHORT).show()), 3000);
                 }
             }
         };
@@ -1455,15 +1453,15 @@ public class GpsTestActivity extends AppCompatActivity
     @SuppressLint("MissingPermission")
     private void checkTimeAndDistance(SharedPreferences settings) {
         double tempMinTimeDouble = Double
-                .valueOf(settings.getString(getString(R.string.pref_key_gps_min_time), "1"));
+                .parseDouble(settings.getString(getString(R.string.pref_key_gps_min_time), "1"));
         long minTimeLong = (long) (tempMinTimeDouble * SECONDS_TO_MILLISECONDS);
 
         if (minTime != minTimeLong ||
-                minDistance != Float.valueOf(
+                minDistance != Float.parseFloat(
                         settings.getString(getString(R.string.pref_key_gps_min_distance), "0"))) {
             // User changed preference values, get the new ones
             minTime = minTimeLong;
-            minDistance = Float.valueOf(
+            minDistance = Float.parseFloat(
                     settings.getString(getString(R.string.pref_key_gps_min_distance), "0"));
             // If the GPS is started, reset the location listener with the new values
             if (mStarted && mProvider != null) {

--- a/GPSTest/src/main/java/com/android/gpstest/NavigationDrawerFragment.java
+++ b/GPSTest/src/main/java/com/android/gpstest/NavigationDrawerFragment.java
@@ -143,7 +143,7 @@ public class NavigationDrawerFragment extends Fragment {
     };
 
     // list of navdrawer items that were actually added to the navdrawer, in order
-    private List<Integer> mNavDrawerItems = new ArrayList<Integer>();
+    private List<Integer> mNavDrawerItems = new ArrayList<>();
 
     // views that correspond to each navdrawer item, null if not yet created
     private View[] mNavDrawerItemViews = null;

--- a/GPSTest/src/main/java/com/android/gpstest/util/IOUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/IOUtils.java
@@ -175,12 +175,12 @@ public class IOUtils {
 
         String[] noPrefix = geoUri.split(":");
         String[] coords = noPrefix[1].split(",");
-        if (isValidLatitude(Double.valueOf(coords[0])) && isValidLongitude(Double.valueOf(coords[1]))) {
+        if (isValidLatitude(Double.parseDouble(coords[0])) && isValidLongitude(Double.parseDouble(coords[1]))) {
             l = new Location("Geo URI");
-            l.setLatitude(Double.valueOf(coords[0]));
-            l.setLongitude(Double.valueOf(coords[1]));
+            l.setLatitude(Double.parseDouble(coords[0]));
+            l.setLongitude(Double.parseDouble(coords[1]));
             if (coords.length == 3) {
-                l.setAltitude(Double.valueOf(coords[2]));
+                l.setAltitude(Double.parseDouble(coords[2]));
             }
         }
 

--- a/GPSTest/src/main/java/com/android/gpstest/util/NmeaUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/NmeaUtils.java
@@ -112,8 +112,8 @@ public class NmeaUtils {
             if (!TextUtils.isEmpty(pdop) && !TextUtils.isEmpty(hdop) && !TextUtils.isEmpty(vdop)) {
                 DilutionOfPrecision dop = null;
                 try {
-                    dop = new DilutionOfPrecision(Double.valueOf(pdop), Double.valueOf(hdop),
-                            Double.valueOf(vdop));
+                    dop = new DilutionOfPrecision(Double.parseDouble(pdop), Double.parseDouble(hdop),
+                            Double.parseDouble(vdop));
                 } catch (NumberFormatException e) {
                     // See https://github.com/barbeau/gpstest/issues/71#issuecomment-263169174
                     Log.e(TAG, "Invalid DOP values in NMEA: " + nmeaSentence);

--- a/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
+++ b/GPSTest/src/main/java/com/android/gpstest/util/UIUtils.java
@@ -533,9 +533,7 @@ public class UIUtils {
                 .setCancelable(false)
                 .setView(view)
                 .setPositiveButton(R.string.ok,
-                        (dialog, which) -> {
-                            IOUtils.openQrCodeReader(activity);
-                        }
+                        (dialog, which) -> IOUtils.openQrCodeReader(activity)
                 ).setNegativeButton(R.string.not_now,
                         (dialog, which) -> {
                             // No op


### PR DESCRIPTION
This "bug report" is really about doing some very basic code cleanup. No functionality has been changed.
1 - cleaned up the autoboxing.. valueOf() returns an Object type where parseXXX() returns a primitive type.
Several places primitive types are used instead of Objects.
2 - A couple of places just simply use the diamond operator.
3 - A couple of places lambda is treated as a statement.. Really minor semantics

Expected behavior
A few less warnings will be emitted by the Android Studio..

Observed behavior
A few warnings from the Android Studio IDE.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Acknowledge that you're contributing your code under Apache v2.0 license

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

Closes https://github.com/barbeau/gpstest/issues/517