### PR TITLE
Simplify loading the signing config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.idea/
 *.iml
 .DS_Store
+secure.properties
+build/

--- a/GPSTest/build.gradle
+++ b/GPSTest/build.gradle
@@ -43,31 +43,22 @@ android {
         disable 'MissingTranslation', 'ExtraTranslation'
     }
 
-    if (project.hasProperty("secure.properties")
-            && new File(project.property("secure.properties")).exists()) {
 
-        Properties props = new Properties()
-        props.load(new FileInputStream(file(project.property("secure.properties"))))
-
-        signingConfigs {
-            debug {
-                storeFile file("gpstest.debug.keystore")
+    signingConfigs {
+        debug {
+             storeFile file("gpstest.debug.keystore")
             }
+        
+        release {
+            if (rootProject.file("secure.properties").exists()) {
+                Properties props = new Properties()
+                props.load(new FileInputStream(rootProject.file("secure.properties")))
 
-            release {
                 storeFile file(props['key.store'])
                 keyAlias props['key.alias']
                 storePassword props['key.storepassword']
                 keyPassword props['key.keypassword']
-            }
-        }
-    } else {
-        signingConfigs {
-            debug {
-                storeFile file("gpstest.debug.keystore")
-            }
-
-            release {
+            } else {
                 // Nothing here
             }
         }


### PR DESCRIPTION
This PR simplifies the project structure by simplifying how the signing configs are included. The `secure.properties` file, if it exists will be read directly rather than read from a property.
Also instructs git to ignore secure.properties file in the root Project(and a build directory).

# TODO
- Modify Build Documentation to reflect the changes(will be pushed if these changes are acceptable)


- [x] Acknowledge that I'm contributing your code under Apache v2.0 license
- [x] Applied the `AndroidStyle.xml` style template to my code in Android Studio.