### PR TITLE
chore: Target SDK version 31

### DIFF
--- a/GPSTest/build.gradle
+++ b/GPSTest/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 29
+        targetSdkVersion 33
         multiDexEnabled true
         // versionCode scheme - first two digits are minSdkVersion, last three digits are build number
         versionCode 18093
@@ -122,7 +122,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.1.0-rc02'
+        kotlinCompilerExtensionVersion '1.4.0'
     }
 
     buildFeatures {
@@ -143,10 +143,9 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     // ViewModel and LiveData
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
-    implementation 'androidx.fragment:fragment-ktx:1.3.6'
+    implementation 'androidx.fragment:fragment-ktx:1.5.6'
 
     // Sliding drawer in map view
     implementation 'com.sothree.slidinguppanel:library:3.4.0'
@@ -158,7 +157,7 @@ dependencies {
     implementation 'com.google.zxing:android-integration:3.3.0'
 
     // Uploading device properties on user request
-    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation 'androidx.core:core-ktx:1.10.0-rc01'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
     implementation 'commons-io:commons-io:2.8.0'
 

--- a/GPSTest/build.gradle
+++ b/GPSTest/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 31
         multiDexEnabled true
         // versionCode scheme - first two digits are minSdkVersion, last three digits are build number
         versionCode 18093

--- a/GPSTest/src/androidTest/java/com/android/gpstest/FormatUtilsTest.kt
+++ b/GPSTest/src/androidTest/java/com/android/gpstest/FormatUtilsTest.kt
@@ -53,7 +53,7 @@ class FormatUtilsTest {
         }
         l.elapsedRealtimeNanos = 123456789
 
-        // Fix,Provider,LatitudeDegrees,LongitudeDegrees,AltitudeMeters,SpeedMps,AccuracyMeters,BearingDegrees,UnixTimeMillis,SpeedAccuracyMps,BearingAccuracyDegrees,elapsedRealtimeNanos,VerticalAccuracyMeters
+        // Fix,Provider,LatitudeDegrees,LongitudeDegrees,AltitudeMeters,SpeedMps,AccuracyMeters,BearingDegrees,UnixTimeMillis,SpeedAccuracyMps,BearingAccuracyDegrees,elapsedRealtimeNanos,VerticalAccuracyMeters,MockLocation
         if (l.isSpeedAccuracySupported() && l.isBearingAccuracySupported() && l.isVerticalAccuracySupported()) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 assertEquals(
@@ -122,7 +122,7 @@ class FormatUtilsTest {
             l.isMock = true
         }
 
-        // Fix,Provider,LatitudeDegrees,LongitudeDegrees,AltitudeMeters,SpeedMps,AccuracyMeters,BearingDegrees,UnixTimeMillis,SpeedAccuracyMps,BearingAccuracyDegrees,elapsedRealtimeNanos,VerticalAccuracyMeters
+        // Fix,Provider,LatitudeDegrees,LongitudeDegrees,AltitudeMeters,SpeedMps,AccuracyMeters,BearingDegrees,UnixTimeMillis,SpeedAccuracyMps,BearingAccuracyDegrees,elapsedRealtimeNanos,VerticalAccuracyMeters,MockLocation
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             assertEquals(
                 "Fix,test,45.34567899,12.45678901,0.0,0.0,0.0,0.0,12345,,,0,,1",

--- a/GPSTest/src/main/AndroidManifest.xml
+++ b/GPSTest/src/main/AndroidManifest.xml
@@ -18,9 +18,9 @@
     package="com.android.gpstest">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <!-- Required for foreground services on P+ -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/GPSTest/src/main/java/com/android/gpstest/ForegroundOnlyLocationService.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ForegroundOnlyLocationService.kt
@@ -304,9 +304,7 @@ class ForegroundOnlyLocationService : LifecycleService() {
                 )
 
                 GlobalScope.launch(Dispatchers.IO) {
-                    if (writeLocationToFile(app, prefs) &&
-                        applicationContext.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                    ) {
+                    if (writeLocationToFile(app, prefs)) {
                         initLogging()
                         csvFileLogger.onLocationChanged(it)
                     }
@@ -338,9 +336,7 @@ class ForegroundOnlyLocationService : LifecycleService() {
                 )
                 // Log Status
                 GlobalScope.launch(Dispatchers.IO) {
-                    if (writeStatusToFile(app, prefs) &&
-                        applicationContext.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                    ) {
+                    if (writeStatusToFile(app, prefs)) {
                         initLogging()
                         csvFileLogger.onGnssStatusChanged(it, currentLocation)
                     }
@@ -367,9 +363,7 @@ class ForegroundOnlyLocationService : LifecycleService() {
                             if (writeNmeaTimestampToLogcat(app, prefs)) it.timestamp else Long.MIN_VALUE
                         )
                     }
-                    if (writeNmeaToFile(app, prefs) &&
-                        applicationContext.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                    ) {
+                    if (writeNmeaToFile(app, prefs)) {
                         initLogging()
                         csvFileLogger.onNmeaReceived(it.timestamp, it.message)
                     }
@@ -393,9 +387,7 @@ class ForegroundOnlyLocationService : LifecycleService() {
                     if (writeNavMessageToLogcat(app, prefs)) {
                         writeNavMessageToAndroidStudio(it)
                     }
-                    if (writeNavMessageToFile(app, prefs) &&
-                        applicationContext.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                    ) {
+                    if (writeNavMessageToFile(app, prefs)) {
                         initLogging()
                         csvFileLogger.onGnssNavigationMessageReceived(it)
                     }
@@ -421,9 +413,7 @@ class ForegroundOnlyLocationService : LifecycleService() {
                             writeMeasurementToLogcat(m)
                         }
                     }
-                    if (writeMeasurementsToFile(app, prefs) &&
-                        applicationContext.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                    ) {
+                    if (writeMeasurementsToFile(app, prefs)) {
                         initLogging()
                         csvFileLogger.onGnssMeasurementsReceived(it)
                     }
@@ -445,9 +435,6 @@ class ForegroundOnlyLocationService : LifecycleService() {
             .onEach {
                 //Log.d(TAG, "Service antennas: $it")
                 GlobalScope.launch(Dispatchers.IO) {
-                    if (!applicationContext.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                        return@launch
-                    }
                     if (writeAntennaInfoToFileCsv(app, prefs) || writeAntennaInfoToFileJson(app, prefs)) {
                         initLogging()
                     }
@@ -473,9 +460,7 @@ class ForegroundOnlyLocationService : LifecycleService() {
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach {
                 //Log.d(TAG, "Service sensor: orientation ${it.values[0]}, tilt ${it.values[1]}")
-                if (writeOrientationToFile(app, prefs) &&
-                    applicationContext.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                ) {
+                if (writeOrientationToFile(app, prefs)) {
                     initLogging()
                     csvFileLogger.onOrientationChanged(it, System.currentTimeMillis(), SystemClock.elapsedRealtime())
                 }
@@ -606,9 +591,6 @@ class ForegroundOnlyLocationService : LifecycleService() {
      * permissions but logging hasn't been started yet.
      */
     private fun initLogging() {
-        if (!applicationContext.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-            return
-        }
         val locationManager = getSystemService(Context.LOCATION_SERVICE) as LocationManager
 
         // Inject time and/or PSDS to make sure timestamps and assistance are as updated as possible
@@ -636,7 +618,7 @@ class ForegroundOnlyLocationService : LifecycleService() {
             // If we've already deleted files on this application execution, don't do it again
             return
         }
-        if (applicationContext.hasPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) && (csvFileLogger.isStarted || jsonFileLogger.isStarted)) {
+        if (csvFileLogger.isStarted || jsonFileLogger.isStarted) {
             // Base directories should be the same, so we only need one of the two (whichever is logging) to clear old files
             var baseDirectory: File = csvFileLogger.baseDirectory
             if (baseDirectory == null) {

--- a/GPSTest/src/main/java/com/android/gpstest/ForegroundOnlyLocationService.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ForegroundOnlyLocationService.kt
@@ -21,6 +21,7 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK
@@ -37,6 +38,7 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.PRIORITY_LOW
+import androidx.core.app.PendingIntentCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleService
@@ -532,7 +534,7 @@ class ForegroundOnlyLocationService : LifecycleService() {
             .bigText(summaryText)
             .setBigContentTitle(titleText)
 
-        // 3. Set up main Intent/Pending Intents for notification.
+        // 3. Set up main Intent/Pending Intents for notification
         val launchActivityIntent = Intent(this, MainActivity::class.java).apply {
             flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
             // NOTE: The above causes the activity/viewmodel to be recreated from scratch for Accuracy when it's already visible
@@ -540,21 +542,23 @@ class ForegroundOnlyLocationService : LifecycleService() {
             // FLAG_ACTIVITY_REORDER_TO_FRONT seems like it should work, but if this is used then onResume() is called
             // again (and onPause() is never called). This seems to freeze up Status into a blank state because GNSS inits again.
         }
-        val openActivityPendingIntent = PendingIntent.getActivity(
+        val openActivityPendingIntent = PendingIntentCompat.getActivity(
             applicationContext,
             System.currentTimeMillis().toInt(),
             launchActivityIntent,
-            0
+            0,
+            false
         )
 
         val cancelIntent = Intent(this, ForegroundOnlyLocationService::class.java).apply {
             putExtra(EXTRA_CANCEL_LOCATION_TRACKING_FROM_NOTIFICATION, true)
         }
-        val stopServicePendingIntent = PendingIntent.getService(
+        val stopServicePendingIntent = PendingIntentCompat.getService(
             applicationContext,
             System.currentTimeMillis().toInt(),
             cancelIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_UPDATE_CURRENT,
+            false
         )
 
         // 4. Build and issue the notification.

--- a/GPSTest/src/main/java/com/android/gpstest/io/BaseFileLogger.java
+++ b/GPSTest/src/main/java/com/android/gpstest/io/BaseFileLogger.java
@@ -80,7 +80,7 @@ public abstract class BaseFileLogger implements FileLogger {
         boolean isNewFile = false;
         String state = Environment.getExternalStorageState();
         if (Environment.MEDIA_MOUNTED.equals(state)) {
-            baseDirectory = new File(Environment.getExternalStorageDirectory(), FILE_PREFIX);
+            baseDirectory = new File(context.getExternalFilesDir(null), FILE_PREFIX);
             baseDirectory.mkdirs();
         } else if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
             logError("Cannot write to external storage.");

--- a/GPSTest/src/main/java/com/android/gpstest/io/CsvFileLogger.java
+++ b/GPSTest/src/main/java/com/android/gpstest/io/CsvFileLogger.java
@@ -146,7 +146,7 @@ public class CsvFileLogger extends BaseFileLogger implements FileLogger {
             writer.newLine();
             writer.write(COMMENT_START);
             writer.write(
-                    "  Fix,Provider,LatitudeDegrees,LongitudeDegrees,AltitudeMeters,SpeedMps,AccuracyMeters,BearingDegrees,UnixTimeMillis,SpeedAccuracyMps,BearingAccuracyDegrees,elapsedRealtimeNanos,VerticalAccuracyMeters");
+                    "  Fix,Provider,LatitudeDegrees,LongitudeDegrees,AltitudeMeters,SpeedMps,AccuracyMeters,BearingDegrees,UnixTimeMillis,SpeedAccuracyMps,BearingAccuracyDegrees,elapsedRealtimeNanos,VerticalAccuracyMeters,MockLocation");
             writer.newLine();
             writer.write(COMMENT_START);
             writer.newLine();

--- a/GPSTest/src/main/java/com/android/gpstest/ui/MainActivity.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ui/MainActivity.kt
@@ -464,7 +464,7 @@ class MainActivity : AppCompatActivity(), NavigationDrawerCallbacks {
                 if (lastLocation != null) {
                     locationString = LocationUtils.printLocationDetails(lastLocation)
                 }
-                LibUIUtils.sendEmail(app, email, locationString, signalInfoViewModel, BuildUtils.getPlayServicesVersion(), prefs)
+                LibUIUtils.sendEmail(this, email, locationString, signalInfoViewModel, BuildUtils.getPlayServicesVersion(), prefs)
             }
         }
         invalidateOptionsMenu()

--- a/GPSTest/src/main/java/com/android/gpstest/ui/Preferences.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ui/Preferences.kt
@@ -163,61 +163,15 @@ class Preferences : PreferenceActivity(), OnSharedPreferenceChangeListener {
             ) as PreferenceCategory
             mMapCategory.removePreference(checkBoxMapType)
         }
-        val manager = getSystemService(LOCATION_SERVICE) as LocationManager
 
-        // If the user chooses to enable any of the file writing preferences, request permission
-        chkLogFileNmea =
-            findPreference(getString(R.string.pref_key_file_nmea_output)) as CheckBoxPreference
-        chkLogFileNmea?.onPreferenceChangeListener =
-            OnPreferenceChangeListener { preference: Preference?, newValue: Any? ->
-                PermissionUtils.requestFileWritePermission(this@Preferences)
-                true
-            }
-        chkLogFileNavMessages =
-            findPreference(getString(R.string.pref_key_file_navigation_message_output)) as CheckBoxPreference
-        chkLogFileNavMessages?.isEnabled = enableNavMessagesPref(app, prefs)
-        chkLogFileNavMessages?.onPreferenceChangeListener =
-            OnPreferenceChangeListener { _: Preference?, _: Any? ->
-                PermissionUtils.requestFileWritePermission(this@Preferences)
-                true
-            }
-        chkLogFileMeasurements =
-            findPreference(getString(R.string.pref_key_file_measurement_output)) as CheckBoxPreference
-        chkLogFileMeasurements?.isEnabled = enableMeasurementsPref(app, prefs);
-        chkLogFileMeasurements?.onPreferenceChangeListener =
-            OnPreferenceChangeListener { preference: Preference?, newValue: Any? ->
-                PermissionUtils.requestFileWritePermission(this@Preferences)
-                true
-            }
-        chkLogFileLocation =
-            findPreference(getString(R.string.pref_key_file_location_output)) as CheckBoxPreference
-        chkLogFileLocation?.onPreferenceChangeListener =
-            OnPreferenceChangeListener { _: Preference?, _: Any? ->
-                PermissionUtils.requestFileWritePermission(this@Preferences)
-                true
-            }
+        // Disable preferences for antenna info logging if it's not supported
+        val manager = getSystemService(LOCATION_SERVICE) as LocationManager
         chkLogFileAntennaJson =
             findPreference(getString(R.string.pref_key_file_antenna_output_json)) as CheckBoxPreference
-        if (SatelliteUtils.isGnssAntennaInfoSupported(manager)) {
-            chkLogFileAntennaJson!!.onPreferenceChangeListener =
-                OnPreferenceChangeListener { _: Preference?, _: Any? ->
-                    PermissionUtils.requestFileWritePermission(this@Preferences)
-                    true
-                }
-        } else {
-            // Not supported
-            chkLogFileAntennaJson!!.isEnabled = false
-        }
         chkLogFileAntennaCsv =
             findPreference(getString(R.string.pref_key_file_antenna_output_csv)) as CheckBoxPreference
-        if (SatelliteUtils.isGnssAntennaInfoSupported(manager)) {
-            chkLogFileAntennaCsv!!.onPreferenceChangeListener =
-                OnPreferenceChangeListener { _: Preference?, _: Any? ->
-                    PermissionUtils.requestFileWritePermission(this@Preferences)
-                    true
-                }
-        } else {
-            // Not supported
+        if(!SatelliteUtils.isGnssAntennaInfoSupported(manager)) {
+            chkLogFileAntennaJson!!.isEnabled = false
             chkLogFileAntennaCsv!!.isEnabled = false
         }
 

--- a/GPSTest/src/main/java/com/android/gpstest/ui/status/StatusScreen.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ui/status/StatusScreen.kt
@@ -113,13 +113,14 @@ fun Filter(totalNumSignals: Int, satelliteMetadata: SatelliteMetadata, onClick: 
         )
         Text(
             text = buildAnnotatedString {
+                val string = stringResource(id = R.string.filter_showall)
                 withStyle(
                     style = SpanStyle(
                         color = MaterialTheme.colors.primary,
                         textDecoration = TextDecoration.Underline
                     )
                 ) {
-                    append(stringResource(id = R.string.filter_showall))
+                    append(string)
                 }
             },
             fontStyle = FontStyle.Italic,

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -36,7 +36,7 @@ The header of the CSV file explains the format for each data type:
 #   Raw,utcTimeMillis,TimeNanos,LeapSecond,TimeUncertaintyNanos,FullBiasNanos,BiasNanos,BiasUncertaintyNanos,DriftNanosPerSecond,DriftUncertaintyNanosPerSecond,HardwareClockDiscontinuityCount,Svid,TimeOffsetNanos,State,ReceivedSvTimeNanos,ReceivedSvTimeUncertaintyNanos,Cn0DbHz,PseudorangeRateMetersPerSecond,PseudorangeRateUncertaintyMetersPerSecond,AccumulatedDeltaRangeState,AccumulatedDeltaRangeMeters,AccumulatedDeltaRangeUncertaintyMeters,CarrierFrequencyHz,CarrierCycles,CarrierPhase,CarrierPhaseUncertainty,MultipathIndicator,SnrInDb,ConstellationType,AgcDb,BasebandCn0DbHz,FullInterSignalBiasNanos,FullInterSignalBiasUncertaintyNanos,SatelliteInterSignalBiasNanos,SatelliteInterSignalBiasUncertaintyNanos,CodeType,ChipsetElapsedRealtimeNanos
 #
 # Location fix format:
-#   Fix,Provider,LatitudeDegrees,LongitudeDegrees,AltitudeMeters,SpeedMps,AccuracyMeters,BearingDegrees,UnixTimeMillis,SpeedAccuracyMps,BearingAccuracyDegrees,elapsedRealtimeNanos,VerticalAccuracyMeters,IsMockLocation
+#   Fix,Provider,LatitudeDegrees,LongitudeDegrees,AltitudeMeters,SpeedMps,AccuracyMeters,BearingDegrees,UnixTimeMillis,SpeedAccuracyMps,BearingAccuracyDegrees,elapsedRealtimeNanos,VerticalAccuracyMeters,MockLocation
 #
 # Navigation message format:
 #   Nav,Svid,Type,Status,MessageId,Sub-messageId,Data(Bytes)
@@ -235,7 +235,7 @@ Android 7.0 and higher:
 * **GNSS Navigation Message** - Navigation messages observed by the GNSS subsystem.  Disabled by default for Android Studio.  To show only this output in Android Monitor, use the search box text `GpsOutputNav`.
 
 Android 12 and higher:
-* `IsMockLocation` for location fixes
+* `MockLocation` for location fixes
 
 ## What devices support pseudorange measurements and navigation messages?
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,14 @@ buildscript {
         compose_version = '1.2.0-alpha05'
         wear_compose_version = '1.0.2'
     }
-    ext.kotlin_version = '1.6.10'
-    ext.hilt_version = '2.40.1'
+    ext.kotlin_version = '1.8.0'
+    ext.hilt_version = '2.45'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // Hilt for dependency injection
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"

--- a/library/src/main/java/com/android/gpstest/library/util/FormatUtils.kt
+++ b/library/src/main/java/com/android/gpstest/library/util/FormatUtils.kt
@@ -271,7 +271,7 @@ object FormatUtils {
 
     /**
      * Returns location data formatted to CSV for logging in the following format:
-     * Fix,Provider,LatitudeDegrees,LongitudeDegrees,AltitudeMeters,SpeedMps,AccuracyMeters,BearingDegrees,UnixTimeMillis,SpeedAccuracyMps,BearingAccuracyDegrees,elapsedRealtimeNanos,VerticalAccuracyMeters,IsMockLocation
+     * Fix,Provider,LatitudeDegrees,LongitudeDegrees,AltitudeMeters,SpeedMps,AccuracyMeters,BearingDegrees,UnixTimeMillis,SpeedAccuracyMps,BearingAccuracyDegrees,elapsedRealtimeNanos,VerticalAccuracyMeters,MockLocation
      */
     @JvmStatic
     fun Location.toLog(): String {

--- a/library/src/main/java/com/android/gpstest/library/util/PermissionUtils.java
+++ b/library/src/main/java/com/android/gpstest/library/util/PermissionUtils.java
@@ -16,6 +16,7 @@
 package com.android.gpstest.library.util;
 
 import android.Manifest;
+import android.Manifest.permission;
 import android.app.Activity;
 import android.content.pm.PackageManager;
 
@@ -32,7 +33,8 @@ public class PermissionUtils {
     public static final int LOCATION_PERMISSION_REQUEST = 1;
 
     public static final String[] REQUIRED_PERMISSIONS = {
-            Manifest.permission.ACCESS_FINE_LOCATION
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION
     };
 
 

--- a/library/src/main/java/com/android/gpstest/library/util/PermissionUtils.java
+++ b/library/src/main/java/com/android/gpstest/library/util/PermissionUtils.java
@@ -24,19 +24,12 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
 public class PermissionUtils {
-
-    private static final String[] FILE_WRITE_REQUIRED_PERMISSIONS = {
-            Manifest.permission.WRITE_EXTERNAL_STORAGE
-    };
-    private static final int FILE_WRITE_PERMISSION_REQUEST = 2;
-
     public static final int LOCATION_PERMISSION_REQUEST = 1;
 
     public static final String[] REQUIRED_PERMISSIONS = {
             Manifest.permission.ACCESS_FINE_LOCATION,
             Manifest.permission.ACCESS_COARSE_LOCATION
     };
-
 
     /**
      * Returns true if all of the provided permissions in requiredPermissions have been granted, or false if they have not
@@ -51,28 +44,5 @@ public class PermissionUtils {
             }
         }
         return true;
-    }
-
-    /**
-     * Requestes the permissions required for writing files.  This is a no-op if the permission is already granted,
-     * otherwise it prompts the user to grant the file writing permissions.
-     *
-     * @param activity
-     */
-    public static void requestFileWritePermission(Activity activity) {
-        if (!hasGrantedFileWritePermission(activity)) {
-            // Request permissions from the user
-            ActivityCompat.requestPermissions(activity, FILE_WRITE_REQUIRED_PERMISSIONS, FILE_WRITE_PERMISSION_REQUEST);
-        }
-    }
-
-    /**
-     * Returns true if the user has granted file write permissions, and false if they have not
-     *
-     * @param activity
-     * @return true if the user has granted file write permissions, and false if they have not
-     */
-    public static boolean hasGrantedFileWritePermission(Activity activity) {
-        return PermissionUtils.hasGrantedPermissions(activity, FILE_WRITE_REQUIRED_PERMISSIONS);
     }
 }

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -239,7 +239,7 @@
 
     <!-- Permissions -->
     <string name="title_location_permission">Need location permission</string>
-    <string name="text_location_permission">GPSTest needs access to your location to show GNSS data. If you select \"Never ask again\" you will need to reinstall the app or enable permissions via system settings.</string>
+    <string name="text_location_permission">GPSTest needs access to your \"Precise\" location to show GNSS data. If you repeatedly select \"Approximate\" or \"Don\'t allow\" you will need to reinstall the app or enable permissions via system settings.</string>
     <string name="ok">OK</string>
     <string name="exit">EXIT</string>
 

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -48,7 +48,7 @@ android {
         viewBinding true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.1.0-rc02'
+        kotlinCompilerExtensionVersion '1.4.0'
     }
     packagingOptions {
         resources {


### PR DESCRIPTION
This PR updates the app to support `targetSdkVersion 31`, including:
- [x] Bump dependencies
- [x] COARSE location permissions
- [x] Pending intent mutability
- [x] Intent filters declaring exported
- [x] Scoped storage

Fixes #619, #447 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Acknowledge that you're contributing your code under Apache v2.0 license

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.