### PR TITLE
Add support for BDS B2b and IRNSS L1. And update signal detection to match the actual BDS

### DIFF
--- a/GPSTest/src/androidTest/java/com/android/gpstest/CarrierFreqUtilsTest.kt
+++ b/GPSTest/src/androidTest/java/com/android/gpstest/CarrierFreqUtilsTest.kt
@@ -220,10 +220,10 @@ class CarrierFreqUtilsTest {
                 true,
                 72f,
                 25f);
-        beidouB2.hasCarrierFrequency = true
-        beidouB2.carrierFrequencyHz = 1207140000.0
+        beidouB2b.hasCarrierFrequency = true
+        beidouB2b.carrierFrequencyHz = 1207140000.0
 
-        label = CarrierFreqUtils.getCarrierFrequencyLabel(beidouB2)
+        label = CarrierFreqUtils.getCarrierFrequencyLabel(beidouB2b)
         assertEquals("B2b", label)
 
         // Beidou B3I
@@ -252,10 +252,10 @@ class CarrierFreqUtilsTest {
                 true,
                 72f,
                 25f);
-        irnssL5.hasCarrierFrequency = true
-        irnssL5.carrierFrequencyHz = 1575420000.0
+        irnssL1.hasCarrierFrequency = true
+        irnssL1.carrierFrequencyHz = 1575420000.0
 
-        label = CarrierFreqUtils.getCarrierFrequencyLabel(irnssL5)
+        label = CarrierFreqUtils.getCarrierFrequencyLabel(irnssL1)
         assertEquals("L1", label)
 
         // IRNSS L5

--- a/GPSTest/src/androidTest/java/com/android/gpstest/CarrierFreqUtilsTest.kt
+++ b/GPSTest/src/androidTest/java/com/android/gpstest/CarrierFreqUtilsTest.kt
@@ -150,7 +150,7 @@ class CarrierFreqUtilsTest {
 
         // Beidou
 
-        // Beidou B1
+        // Beidou B1I
         val beidouB1 = SatelliteStatus(1,
                 GnssType.BEIDOU,
                 30f,
@@ -163,22 +163,7 @@ class CarrierFreqUtilsTest {
         beidouB1.carrierFrequencyHz = 1561098000.0
 
         label = CarrierFreqUtils.getCarrierFrequencyLabel(beidouB1)
-        assertEquals("B1", label)
-
-        // Beidou B1-2
-        val beidouB1_2 = SatelliteStatus(1,
-                GnssType.BEIDOU,
-                30f,
-                true,
-                true,
-                true,
-                72f,
-                25f);
-        beidouB1_2.hasCarrierFrequency = true
-        beidouB1_2.carrierFrequencyHz = 1589742000.0
-
-        label = CarrierFreqUtils.getCarrierFrequencyLabel(beidouB1_2)
-        assertEquals("B1-2", label)
+        assertEquals("B1I", label)
 
         // Beidou B1C
         val beidouB1c = SatelliteStatus(1,
@@ -210,21 +195,6 @@ class CarrierFreqUtilsTest {
         label = CarrierFreqUtils.getCarrierFrequencyLabel(beidouB1c202)
         assertEquals("B1C", label)
 
-        // Beidou B2
-        val beidouB2 = SatelliteStatus(1,
-                GnssType.BEIDOU,
-                30f,
-                true,
-                true,
-                true,
-                72f,
-                25f);
-        beidouB2.hasCarrierFrequency = true
-        beidouB2.carrierFrequencyHz = 1207140000.0
-
-        label = CarrierFreqUtils.getCarrierFrequencyLabel(beidouB2)
-        assertEquals("B2", label)
-
         // Beidou B2a
         val beidouB2a = SatelliteStatus(1,
                 GnssType.BEIDOU,
@@ -240,7 +210,23 @@ class CarrierFreqUtilsTest {
         label = CarrierFreqUtils.getCarrierFrequencyLabel(beidouB2a)
         assertEquals("B2a", label)
 
-        // Beidou B3
+	
+        // Beidou B2b
+        val beidouB2b = SatelliteStatus(1,
+                GnssType.BEIDOU,
+                30f,
+                true,
+                true,
+                true,
+                72f,
+                25f);
+        beidouB2.hasCarrierFrequency = true
+        beidouB2.carrierFrequencyHz = 1207140000.0
+
+        label = CarrierFreqUtils.getCarrierFrequencyLabel(beidouB2)
+        assertEquals("B2b", label)
+
+        // Beidou B3I
         val beidouB3 = SatelliteStatus(1,
                 GnssType.BEIDOU,
                 30f,
@@ -253,9 +239,24 @@ class CarrierFreqUtilsTest {
         beidouB3.carrierFrequencyHz = 1268520000.0
 
         label = CarrierFreqUtils.getCarrierFrequencyLabel(beidouB3)
-        assertEquals("B3", label)
+        assertEquals("B3I", label)
 
         // IRNSS
+
+        // IRNSS L1
+        val irnssL1 = SatelliteStatus(1,
+                GnssType.IRNSS,
+                30f,
+                true,
+                true,
+                true,
+                72f,
+                25f);
+        irnssL5.hasCarrierFrequency = true
+        irnssL5.carrierFrequencyHz = 1575420000.0
+
+        label = CarrierFreqUtils.getCarrierFrequencyLabel(irnssL5)
+        assertEquals("L1", label)
 
         // IRNSS L5
         val irnssL5 = SatelliteStatus(1,
@@ -732,7 +733,7 @@ class CarrierFreqUtilsTest {
     fun testIsPrimaryCarrier() {
         assertTrue(CarrierFreqUtils.isPrimaryCarrier("L1"))
         assertTrue(CarrierFreqUtils.isPrimaryCarrier("E1"))
-        assertTrue(CarrierFreqUtils.isPrimaryCarrier("B1"))
+        assertTrue(CarrierFreqUtils.isPrimaryCarrier("B1I"))
         assertTrue(CarrierFreqUtils.isPrimaryCarrier("B1C"))
         assertTrue(CarrierFreqUtils.isPrimaryCarrier("L1-C"))
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -6,7 +6,7 @@ Supports dual-frequency* GNSS for:
 • GLONASS (Russia) (L1, L2, L3, L5)
 • QZSS (Japan) (L1, L2, L5, L6)
 • BeiDou/COMPASS (China) (B1I, B2a, B2b, B3I)
-• IRNSS/NavIC (India) (L5, S)
+• IRNSS/NavIC (India) (L1, L5, S)
 • Various satellite-based augmentation systems SBAS (e.g., GAGAN, Anik F1, Galaxy 15, Inmarsat 3-F2, Inmarsat 4-F3, SES-5) (L1, L5)
 
 *Dual-frequency GNSS requires device hardware support and Android 8.0 Oreo or higher. More at https://medium.com/@sjbarbeau/dual-frequency-gnss-on-android-devices-152b8826e1c.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -5,7 +5,7 @@ Supports dual-frequency* GNSS for:
 • Galileo (European Union) (E1, E5, E5a, E5b, E6)
 • GLONASS (Russia) (L1, L2, L3, L5)
 • QZSS (Japan) (L1, L2, L5, L6)
-• BeiDou/COMPASS (China) (B1, B1-2, B2, B2a, B3)
+• BeiDou/COMPASS (China) (B1I, B2a, B2b, B3I)
 • IRNSS/NavIC (India) (L5, S)
 • Various satellite-based augmentation systems SBAS (e.g., GAGAN, Anik F1, Galaxy 15, Inmarsat 3-F2, Inmarsat 4-F3, SES-5) (L1, L5)
 

--- a/library/src/main/java/com/android/gpstest/library/util/CarrierFreqUtils.java
+++ b/library/src/main/java/com/android/gpstest/library/util/CarrierFreqUtils.java
@@ -126,17 +126,15 @@ public class CarrierFreqUtils {
      */
     public static String getBeidoucCf(double carrierFrequencyMhz) {
         if (MathUtils.fuzzyEquals(carrierFrequencyMhz, 1561.098, CF_TOLERANCE_MHZ)) {
-            return "B1";
-        } else if (MathUtils.fuzzyEquals(carrierFrequencyMhz, 1589.742, CF_TOLERANCE_MHZ)) {
-            return "B1-2";
+            return "B1I";
         } else if (MathUtils.fuzzyEquals(carrierFrequencyMhz, 1575.42, CF_TOLERANCE_MHZ)) {
             return "B1C";
-        } else if (MathUtils.fuzzyEquals(carrierFrequencyMhz, 1207.14, CF_TOLERANCE_MHZ)) {
-            return "B2";
         } else if (MathUtils.fuzzyEquals(carrierFrequencyMhz, 1176.45, CF_TOLERANCE_MHZ)) {
             return "B2a";
+        } else if (MathUtils.fuzzyEquals(carrierFrequencyMhz, 1207.14, CF_TOLERANCE_MHZ)) {
+            return "B2b";
         } else if (MathUtils.fuzzyEquals(carrierFrequencyMhz, 1268.52, CF_TOLERANCE_MHZ)) {
-            return "B3";
+            return "B3I";
         } else {
             return CF_UNKNOWN;
         }
@@ -188,7 +186,9 @@ public class CarrierFreqUtils {
      * @return carrier frequency label
      */
     public static String getIrnssCf(double carrierFrequencyMhz) {
-        if (MathUtils.fuzzyEquals(carrierFrequencyMhz, 1176.45, CF_TOLERANCE_MHZ)) {
+        if (MathUtils.fuzzyEquals(carrierFrequencyMhz, 1575.42, CF_TOLERANCE_MHZ)) {
+            return "L1";
+        } else if (MathUtils.fuzzyEquals(carrierFrequencyMhz, 1176.45, CF_TOLERANCE_MHZ)) {
             return "L5";
         } else if (MathUtils.fuzzyEquals(carrierFrequencyMhz, 2492.028, CF_TOLERANCE_MHZ)) {
             return "S";
@@ -289,6 +289,6 @@ public class CarrierFreqUtils {
      * * frequency
      */
     public static boolean isPrimaryCarrier(String label) {
-        return label.equals("L1") || label.equals("E1") || label.equals("L1-C") || label.equals("B1") || label.equals("B1C");
+        return label.equals("L1") || label.equals("E1") || label.equals("L1-C") || label.equals("B1I") || label.equals("B1C");
     }
 }


### PR DESCRIPTION
Add the ability to properly detect BDS B2b and IRNSS L1.

1. BDS "B2" is rename to "B2b", as B2I signal is marked as obsolete in official press release and due to the fact that they share the same frequency. I highly doubt any civilian device is going to support B2I. More detail see #652

> Source: http://www.beidou.gov.cn/yw/xwzx/201712/t20171226_11012.html

![QQ截图20231024161333](https://github.com/barbeau/gpstest/assets/31060534/1466e440-51ff-4ad8-9535-5985e35833c1)

2. IRNSS L1 support, see #653. 

3. Remove the code for "B1-2" signal. I think it's an out-of-date mistake. I have checked every website, paper, press there is no such signal.

4. Rename B1 and B3 to B1I and B3I to match the official name. (It's uppercase "i", not lowercase “L”)
Maybe this will reduce user's confusion. as there are two B1 band.
And yes B3I is not obsolete. It may be supported by consumer market one day.

And the precise frequency for B2b and E5b appear to be 1207.139970 MHz. But GPSTest already display E5b properly. 
So I think it's fine.
![QQ截图20231024162039](https://github.com/barbeau/gpstest/assets/31060534/ed167e17-c02f-4d3f-84e8-011361e1886b)


- [√ ] Acknowledge that you're contributing your code under Apache v2.0 license

- [√ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.