### PR TITLE
Sets the correct color for the SouthPAN Legend diamond and dashes

### DIFF
--- a/GPSTest/src/main/java/com/android/gpstest/ui/sky/SkyFragment.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ui/sky/SkyFragment.kt
@@ -314,7 +314,9 @@ class SkyFragment : Fragment() {
             legend.skyLegendShapeLine15a,
             legend.skyLegendShapeLine15b,
             legend.skyLegendShapeLine16a,
-            legend.skyLegendShapeLine16b
+            legend.skyLegendShapeLine16b,
+            legend.skyLegendShapeLine17a,
+            legend.skyLegendShapeLine17b
         )
 
         // Shape Legend shapes
@@ -331,7 +333,8 @@ class SkyFragment : Fragment() {
             legend.skyLegendDiamond4,
             legend.skyLegendDiamond5,
             legend.skyLegendDiamond6,
-            legend.skyLegendDiamond7
+            legend.skyLegendDiamond7,
+            legend.skyLegendDiamond8
         )
     }
 


### PR DESCRIPTION
Adds the diamond and dashes to the list of shapes and lines so that the colors get updated appropriately when dark mode is turned on

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Acknowledge that you're contributing your code under Apache v2.0 license

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.