### PR TITLE
CI: terminate crashpad_handler process on emulator exit (Fix #729)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -145,6 +145,6 @@ jobs:
           disable-animations: true
           script: |
             adb wait-for-device
-            ./gradlew ${{ matrix.tasks }} -x lint --stacktrace
+            ./gradlew ${{ matrix.tasks }} -x lint --stacktrace && killall -INT crashpad_handler || true
           arch: x86_64
           profile: Nexus 6


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Acknowledge that you're contributing your code under Apache v2.0 license
- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

This PR fix bug ticket #729 by ensuring that the crashpad_handler process doesn't hang indefinitely after emulator exit