### PR TITLE
Fix Gradle warnings

### DIFF
--- a/GPSTest/build.gradle
+++ b/GPSTest/build.gradle
@@ -10,7 +10,7 @@ android {
     defaultConfig {
         minSdkVersion 24
         targetSdkVersion 34
-        multiDexEnabled true
+        multiDexEnabled = true
         // versionCode scheme - first two digits are minSdkVersion, last three digits are build number
         versionCode 24099
         versionName "3.10.5"
@@ -22,7 +22,7 @@ android {
 
     buildFeatures {
         // Enables Jetpack Compose for this module
-        compose true
+        compose = true
     }
 
     flavorDimensions "map"
@@ -81,9 +81,9 @@ android {
     buildTypes {
         release {
             minifyEnabled true
-            shrinkResources true
+            shrinkResources = true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
-            signingConfig signingConfigs.release
+            signingConfig = signingConfigs.release
         }
         // Append the version name to the end of aligned APKs
         android.applicationVariants.all { variant ->
@@ -108,16 +108,16 @@ android {
 
     testOptions {
         unitTests.returnDefaultValues = true
-        unitTests.includeAndroidResources true
+        unitTests.includeAndroidResources = true
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0'
+        kotlinCompilerExtensionVersion = '1.4.0'
     }
 
     buildFeatures {
-        dataBinding true
-        viewBinding true
+        dataBinding = true
+        viewBinding = true
     }
 
     buildFeatures {
@@ -129,10 +129,10 @@ android {
 
     useLibrary 'android.test.base'
     useLibrary 'android.test.mock'
-    namespace 'com.android.gpstest'
+    namespace = 'com.android.gpstest'
     lint {
         disable 'MissingTranslation', 'ExtraTranslation', 'StringFormatInvalid'
-        sarifReport true
+        sarifReport = true
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' } // For MPAndroidChart
+        maven { url = 'https://jitpack.io' } // For MPAndroidChart
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,12 +5,12 @@ plugins {
 }
 
 android {
-    namespace 'com.android.gpstest.library'
-    compileSdk 33
+    namespace = 'com.android.gpstest.library'
+    compileSdk = 33
 
     defaultConfig {
-        minSdk 24
-        targetSdk 32
+        minSdk = 24
+        targetSdk = 32
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -25,8 +25,8 @@ android {
 
 
     buildFeatures {
-        dataBinding true
-        viewBinding true
+        dataBinding = true
+        viewBinding = true
     }
 
     dataBinding {

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -7,17 +7,17 @@ plugins {
 }
 
 android {
-    namespace 'com.android.gpstest.wear'
-    compileSdk 33
+    namespace = 'com.android.gpstest.wear'
+    compileSdk = 33
 
     defaultConfig {
         applicationId "com.android.gpstest.wear"
-        minSdk 25
-        targetSdk 32
+        minSdk = 25
+        targetSdk = 32
         versionCode 1
         versionName "1.0"
         vectorDrawables {
-            useSupportLibrary true
+            useSupportLibrary = true
         }
 
     }
@@ -44,12 +44,12 @@ android {
                 "-Xjvm-default=all"]
     }
     buildFeatures {
-        compose true
-        dataBinding true
-        viewBinding true
+        compose = true
+        dataBinding = true
+        viewBinding = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0'
+        kotlinCompilerExtensionVersion = '1.4.0'
     }
     packagingOptions {
         resources {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Acknowledge that you're contributing your code under Apache v2.0 license
- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

Hi !

This PR doesn't introduce functional changes, it only fixes Gradle warnings about deprecated Groovy DSL syntax, and use the modern notation for linting configuration and ressource packaging configuration:

* **Standardized Boolean Assignments**: I've standardized the assignment syntax for boolean properties across multiple `build.gradle` files, changing implicit `property true` to explicit `property = true`. This addresses common Gradle warnings related to deprecated assignment styles.
* **Updated Resource Packaging Configuration**: The `packagingOptions` block in `GPSTest/build.gradle` has been refactored to use the modern `resources` block with `excludes +=` and `pickFirsts +=`. This provides a clearer and more idiomatic way to manage resource exclusions and conflicts.
* **Reorganized Linting Configurations**: I've relocated the `lintOptions` configurations in `GPSTest/build.gradle` and `library/build.gradle` into the dedicated `lint` block within the `android` configuration. This aligns with current Gradle Android plugin recommendations for linting setup.

This fixes the following warnings in Gradle: `Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated.`