### PR TITLE
Add a timestamp box to the "Share Coordinates" window

### DIFF
--- a/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
@@ -75,13 +75,13 @@ class ShareLocationFragment : Fragment() {
             if (location == null) return ""
             return when {
                 chipDMS.isChecked -> IOUtils.createLocationShare(
-                    LibUIUtils.getDMSFromLocation(Application.app, location.latitude, CoordinateType.LATITUDE),
-                    LibUIUtils.getDMSFromLocation(Application.app, location.longitude, CoordinateType.LONGITUDE),
+                    LibUIUtils.getDMSFromLocation(app, location.latitude, CoordinateType.LATITUDE),
+                    LibUIUtils.getDMSFromLocation(app, location.longitude, CoordinateType.LONGITUDE),
                     if (location.hasAltitude() && includeAltitude.isChecked) location.altitude.toString() else null
                 )
                 chipDegreesDecimalMin.isChecked -> IOUtils.createLocationShare(
-                    LibUIUtils.getDDMFromLocation(Application.app, location.latitude, CoordinateType.LATITUDE),
-                    LibUIUtils.getDDMFromLocation(Application.app, location.longitude, CoordinateType.LONGITUDE),
+                    LibUIUtils.getDDMFromLocation(app, location.latitude, CoordinateType.LATITUDE),
+                    LibUIUtils.getDDMFromLocation(app, location.longitude, CoordinateType.LONGITUDE),
                     if (location.hasAltitude() && includeAltitude.isChecked) location.altitude.toString() else null
                 )
                 else -> IOUtils.createLocationShare(location, includeAltitude.isChecked)

--- a/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
@@ -89,9 +89,7 @@ class ShareLocationFragment : Fragment() {
         // Single entry point that rewrites the locationValue TextView.
         // Combines the coordinate string from coordinatesOnly() with an optional timestamp
         // line when the "include timestamp" checkbox is selected.
-        // Every UI event (altitude/timestamp toggles, chip selection, initial display)
-        // funnels through this function, so the timestamp suffix logic lives
-        // in one place rather than being duplicated across each listener.
+        // Every UI event funnels through this function.
         fun refreshLocationText() {
             if (location == null) return
             val base = coordinatesOnly()

--- a/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
@@ -69,8 +69,6 @@ class ShareLocationFragment : Fragment() {
 
         // Returns the location as a plain coordinate string in the currently selected
         // coordinate format, with altitude appended when the "include altitude" checkbox is on.
-        // Moved into a function so the per-chip listeners don't each need their own
-        // copy of the three-way branch
         fun coordinatesOnly(): String {
             if (location == null) return ""
             return when {

--- a/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
@@ -33,6 +33,7 @@ class ShareLocationFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         val locationValue = view.findViewById<TextView>(R.id.location_value)
         val includeAltitude = view.findViewById<CheckBox>(R.id.include_altitude)
+        val includeTimestamp = view.findViewById<CheckBox>(R.id.include_timestamp)
         val noLocation = view.findViewById<TextView>(R.id.no_location)
         val locationCopy: MaterialButton = view.findViewById(R.id.location_copy)
         val locationGeohack: MaterialButton = view.findViewById(R.id.location_geohack)
@@ -49,6 +50,7 @@ class ShareLocationFragment : Fragment() {
             // No location - Hide the location info
             locationValue.visibility = View.GONE
             includeAltitude.visibility = View.GONE
+            includeTimestamp.visibility = View.GONE
             chipGroup.visibility = View.GONE
             locationCopy.visibility = View.GONE
             locationGeohack.visibility = View.GONE
@@ -59,77 +61,94 @@ class ShareLocationFragment : Fragment() {
             noLocation.visibility = View.GONE
         }
 
-        // Set default state of include altitude view
+        // Set default state of include altitude / include timestamp views
         val includeAltitudePref = Application.prefs.getBoolean(Application.app.getString(R.string.pref_key_share_include_altitude), false)
         includeAltitude.isChecked = includeAltitudePref
+        val includeTimestampPref = Application.prefs.getBoolean(Application.app.getString(R.string.pref_key_share_include_timestamp), false)
+        includeTimestamp.isChecked = includeTimestampPref
 
-        // Check selected coordinate format and show in UI
+        // Returns the location as a plain coordinate string in the currently selected
+        // coordinate format, with altitude appended when the "include altitude" checkbox is on.
+        // Moved into a function so the per-chip listeners don't each need their own
+        // copy of the three-way branch
+        fun coordinatesOnly(): String {
+            if (location == null) return ""
+            return when {
+                chipDMS.isChecked -> IOUtils.createLocationShare(
+                    LibUIUtils.getDMSFromLocation(Application.app, location.latitude, CoordinateType.LATITUDE),
+                    LibUIUtils.getDMSFromLocation(Application.app, location.longitude, CoordinateType.LONGITUDE),
+                    if (location.hasAltitude() && includeAltitude.isChecked) location.altitude.toString() else null
+                )
+                chipDegreesDecimalMin.isChecked -> IOUtils.createLocationShare(
+                    LibUIUtils.getDDMFromLocation(Application.app, location.latitude, CoordinateType.LATITUDE),
+                    LibUIUtils.getDDMFromLocation(Application.app, location.longitude, CoordinateType.LONGITUDE),
+                    if (location.hasAltitude() && includeAltitude.isChecked) location.altitude.toString() else null
+                )
+                else -> IOUtils.createLocationShare(location, includeAltitude.isChecked)
+            }
+        }
+
+        // Single entry point that rewrites the locationValue TextView.
+        // Combines the coordinate string from coordinatesOnly() with an optional timestamp
+        // line when the "include timestamp" checkbox is selected.
+        // Every UI event (altitude/timestamp toggles, chip selection, initial display)
+        // funnels through this functtion, so the timestamp suffix logic lives
+        // in one place rather than being duplicated across each listener.
+        fun refreshLocationText() {
+            if (location == null) return
+            val base = coordinatesOnly()
+            locationValue.text = if (includeTimestamp.isChecked) {
+                base + "\n" + IOUtils.formatLocationTimestamp(location.time)
+            } else {
+                base
+            }
+        }
+
+        // Check selected coordinate format and show in UI.
+        // The TextView argument to formatLocationForDisplay() is passed as null:
+        // We no longer let that helper write the location string directly,
+        // instead refreshLocationText() owns that logic and the timestamp
+        // suffix is applied consistently.
+        // formatLocationForDisplay() is still called for its side effect of
+        // selecting the correct chip based on the saved coordinate format preference.
         val coordinateFormat = Application.prefs.getString(Application.app.getString(R.string.pref_key_coordinate_format), Application.app.getString(R.string.preferences_coordinate_format_dd_key))
         if (location != null) {
             LibUIUtils.formatLocationForDisplay(
                 app,
                 location,
-                locationValue,
+                null,
                 includeAltitude.isChecked,
                 chipDecimalDegrees,
                 chipDMS,
                 chipDegreesDecimalMin,
                 coordinateFormat
             )
+            refreshLocationText()
         }
 
-        // Change the location text when the user toggles the altitude checkbox
+        // All five listeners below previously contained their own coordinate-formatting branches.
+        // They are now one-liners that delegate to refreshLocationText(), which
+        // centralises both the coordinate formatting (via coordinatesOnly()) and the
+        // optional timestamp suffix. The altitude / timestamp listeners additionally
+        // persist their checked state to SharedPreferences.
         includeAltitude.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
-            var format = "dd"
-            if (chipDecimalDegrees.isChecked) {
-                format = "dd"
-            } else if (chipDMS.isChecked) {
-                format = "dms"
-            } else if (chipDegreesDecimalMin.isChecked) {
-                format = "ddm"
-            }
-            if (location != null) {
-                LibUIUtils.formatLocationForDisplay(
-                    app,
-                    location,
-                    locationValue,
-                    isChecked,
-                    chipDecimalDegrees,
-                    chipDMS,
-                    chipDegreesDecimalMin,
-                    format
-                )
-            }
+            refreshLocationText()
             PreferenceUtils.saveBoolean(Application.app.getString(R.string.pref_key_share_include_altitude), isChecked, prefs)
         }
 
+        includeTimestamp.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
+            refreshLocationText()
+            PreferenceUtils.saveBoolean(Application.app.getString(R.string.pref_key_share_include_timestamp), isChecked, prefs)
+        }
+
         chipDecimalDegrees.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
-            if (isChecked) {
-                if (location != null) {
-                    locationValue.text =
-                        IOUtils.createLocationShare(location, includeAltitude.isChecked)
-                }
-            }
+            if (isChecked) refreshLocationText()
         }
         chipDMS.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
-            if (isChecked) {
-                if (location != null) {
-                    locationValue.text = IOUtils.createLocationShare(
-                        LibUIUtils.getDMSFromLocation(Application.app, location.latitude, CoordinateType.LATITUDE),
-                            LibUIUtils.getDMSFromLocation(Application.app, location.longitude, CoordinateType.LONGITUDE),
-                            if (location.hasAltitude() && includeAltitude.isChecked) location.altitude.toString() else null)
-                }
-            }
+            if (isChecked) refreshLocationText()
         }
         chipDegreesDecimalMin.setOnCheckedChangeListener { _: CompoundButton?, isChecked: Boolean ->
-            if (isChecked) {
-                if (location != null) {
-                    locationValue.text = IOUtils.createLocationShare(
-                        LibUIUtils.getDDMFromLocation(Application.app, location.latitude, CoordinateType.LATITUDE),
-                            LibUIUtils.getDDMFromLocation(Application.app, location.longitude, CoordinateType.LONGITUDE),
-                            if (location.hasAltitude() && includeAltitude.isChecked) location.altitude.toString() else null)
-                }
-            }
+            if (isChecked) refreshLocationText()
         }
 
         locationCopy.setOnClickListener { _: View? ->
@@ -162,11 +181,12 @@ class ShareLocationFragment : Fragment() {
             }
         }
         locationShare.setOnClickListener { _: View? ->
-            // Send the location as a Geo URI (e.g., in an email) if the user has decimal degrees
-            // selected, otherwise send plain text version
+            // Send the location as a Geo URI (e.g., in an email) when decimal degrees are selected
+            // and no timestamp is requested; otherwise send the plain text version so the timestamp
+            // (which has no place in a geo: URI) is preserved.
             if (location != null) {
                 val intent = Intent(Intent.ACTION_SEND)
-                val text: String = if (chipDecimalDegrees.isChecked) {
+                val text: String = if (chipDecimalDegrees.isChecked && !includeTimestamp.isChecked) {
                     IOUtils.createGeoUri(app, location, includeAltitude.isChecked)
                 } else {
                     locationValue.text.toString()

--- a/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
@@ -90,7 +90,7 @@ class ShareLocationFragment : Fragment() {
         // Combines the coordinate string from coordinatesOnly() with an optional timestamp
         // line when the "include timestamp" checkbox is selected.
         // Every UI event (altitude/timestamp toggles, chip selection, initial display)
-        // funnels through this functtion, so the timestamp suffix logic lives
+        // funnels through this function, so the timestamp suffix logic lives
         // in one place rather than being duplicated across each listener.
         fun refreshLocationText() {
             if (location == null) return

--- a/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
+++ b/GPSTest/src/main/java/com/android/gpstest/ui/share/ShareLocationFragment.kt
@@ -97,8 +97,8 @@ class ShareLocationFragment : Fragment() {
         fun refreshLocationText() {
             if (location == null) return
             val base = coordinatesOnly()
-            locationValue.text = if (includeTimestamp.isChecked) {
-                base + "\n" + IOUtils.formatLocationTimestamp(location.time)
+            locationValue.text = if (includeTimestamp.isChecked && location.time > 0) {
+                "$base\n${IOUtils.formatLocationTimestamp(location.time)}"
             } else {
                 base
             }

--- a/GPSTest/src/main/res/layout/share_location.xml
+++ b/GPSTest/src/main/res/layout/share_location.xml
@@ -88,7 +88,6 @@
         android:id="@+id/include_timestamp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/button_margin"
         android:text="@string/include_timestamp"
         app:layout_constraintTop_toBottomOf="@id/include_altitude"
         app:layout_constraintStart_toStartOf="parent" />
@@ -98,6 +97,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="bottom"
+        app:barrierMargin="@dimen/button_margin"
         app:constraint_referenced_ids="include_altitude,include_timestamp" />
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/GPSTest/src/main/res/layout/share_location.xml
+++ b/GPSTest/src/main/res/layout/share_location.xml
@@ -80,9 +80,17 @@
         android:id="@+id/include_altitude"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/button_margin"
         android:text="@string/include_altitude"
         app:layout_constraintTop_toBottomOf="@id/scroll_coordinate_format"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <CheckBox
+        android:id="@+id/include_timestamp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/button_margin"
+        android:text="@string/include_timestamp"
+        app:layout_constraintTop_toBottomOf="@id/include_altitude"
         app:layout_constraintStart_toStartOf="parent" />
 
     <androidx.constraintlayout.widget.Barrier
@@ -90,7 +98,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="bottom"
-        app:constraint_referenced_ids="include_altitude" />
+        app:constraint_referenced_ids="include_altitude,include_timestamp" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/location_button_layout"

--- a/library/src/main/java/com/android/gpstest/library/util/IOUtils.java
+++ b/library/src/main/java/com/android/gpstest/library/util/IOUtils.java
@@ -45,8 +45,12 @@ import java.io.File;
 import java.io.FileFilter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 public class IOUtils {
 
@@ -267,6 +271,18 @@ public class IOUtils {
             locationString += "," + altitude;
         }
         return locationString;
+    }
+
+    /**
+     * Returns the provided epoch-millisecond timestamp formatted as
+     * "YYYY-MM-DD HH:MM:SS &lt;time zone&gt;",
+     * in the device's default time zone.
+     */
+    public static String formatLocationTimestamp(long timeMillis) {
+        // Use an ISO timestamp for the output, plus time zone
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z", Locale.US);
+        format.setTimeZone(TimeZone.getDefault());
+        return format.format(new Date(timeMillis));
     }
 
     /**

--- a/library/src/main/res/values/do_not_translate.xml
+++ b/library/src/main/res/values/do_not_translate.xml
@@ -121,6 +121,7 @@
     <string name="pref_key_never_show_clear_assist_warning">never_show_clear_assist_warning</string>
     <string name="pref_key_coordinate_format">coordinate_format</string>
     <string name="pref_key_share_include_altitude">share_include_altitude</string>
+    <string name="pref_key_share_include_timestamp">share_include_timestamp</string>
 
     <string name="pref_key_never_show_qr_code_instructions">never_show_qr_code_instructions</string>
     <string name="pref_key_preferred_distance_units_v2">preference_distance_units_v2</string>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="log_error">Something went wrong with file logging. Did you allow file/storage permissions? Try re-enabling a file logging option in Settings and tap "Allow" when prompted.</string>
     <string name="no_location">Try sharing your location after getting a GNSS fix…</string>
     <string name="include_altitude">Include altitude</string>
+    <string name="include_timestamp">Include timestamp</string>
     <string name="set_fix_frequency">Set Fix Frequency</string>
     <string name="force_time_injection_success">Submitted time injection request.</string>
     <string name="force_time_injection_failure">Device does not support injecting time data.


### PR DESCRIPTION
The checkbox is off by default, and adds a second line with the current time when ticked on.
Also simplify the logic around the generation of the coordinates string.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Acknowledge that you're contributing your code under Apache v2.0 license

- [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.